### PR TITLE
KFold cross-validation

### DIFF
--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -141,7 +141,7 @@ impl BaseKFold for KFold {
 
         let mut return_values: Vec<Vec<usize>> = Vec::new();
         let mut current: usize = 0;
-        for fold_size in fold_sizes {
+        for fold_size in fold_sizes.drain(..) {
             let stop = current + fold_size;
             println!("current, stop {:?}, {:?}", &current, &stop);
             return_values.push(
@@ -155,7 +155,7 @@ impl BaseKFold for KFold {
 
     }
 
-    // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<&M> {
+    // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<&M> {
     //     // Python implementation
     //     // for test_index in self._iter_test_indices(X, y, groups):
     //     //     test_mask = np.zeros(_num_samples(X), dtype=bool)

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -110,30 +110,24 @@ impl BaseKFold for KFold {
     fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>> {
         // number of samples (rows) in the matrix
         let n_samples: usize = x.shape().1;
-        println!("n {:?}", &n_samples);
 
         // initialise indices
         let indices: Vec<usize> = (0..n_samples).collect();
-        println!("starting indices{:?}", &indices);
 
         //  return a new array of given shape n_split, filled with each element of n_samples divided by n_splits.
         let mut fold_sizes = vec![n_samples / self.n_splits as usize; self.n_splits as usize];
-        println!("fold size {:?}", &fold_sizes);
 
         // increment by one if odd
         for i in 0..(n_samples % self.n_splits as usize) {
             fold_sizes[i] = fold_sizes[i] + 1;
         }
-        println!("fold size after correction{:?}", &fold_sizes);
 
         // generate the right array of arrays for test indices
         let mut return_values: Vec<Vec<usize>> = Vec::with_capacity(self.n_splits as usize);
         let mut current: usize = 0;
         for fold_size in fold_sizes.drain(..) {
             let stop = current + fold_size;
-            println!("current, stop {:?}, {:?}", &current, &stop);
             return_values.push(indices[current..stop].to_vec());
-            println!("loop {:?}", &return_values);
             current = stop
         }
 
@@ -157,7 +151,6 @@ impl BaseKFold for KFold {
     fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)> {
         let n_samples: usize = x.shape().1;
         let indices: Vec<usize> = (0..n_samples).collect();
-        println!("starting indices{:?}", &indices);
 
         let mut return_values: Vec<(Vec<usize>, Vec<usize>)> =
             Vec::with_capacity(self.n_splits as usize); // TODO: init nested vecs with capacities by getting the length of test_index vecs
@@ -214,7 +207,6 @@ mod tests {
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 33);
         let test_indices = k.test_indices(&x);
 
-        println!("{:?}", &test_indices);
         assert_eq!(test_indices[0], (0..11).collect::<Vec<usize>>());
         assert_eq!(test_indices[1], (11..22).collect::<Vec<usize>>());
         assert_eq!(test_indices[2], (22..33).collect::<Vec<usize>>());
@@ -226,7 +218,6 @@ mod tests {
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 34);
         let test_indices = k.test_indices(&x);
 
-        println!("{:?}", &test_indices);
         assert_eq!(test_indices[0], (0..12).collect::<Vec<usize>>());
         assert_eq!(test_indices[1], (12..23).collect::<Vec<usize>>());
         assert_eq!(test_indices[2], (23..34).collect::<Vec<usize>>());
@@ -239,6 +230,7 @@ mod tests {
         let test_masks = k.test_masks(&x);
 
         for t in &test_masks[0][0..11] {
+            // TODO: this can be prob done better
             assert_eq!(*t, true)
         }
         for t in &test_masks[0][11..22] {
@@ -258,7 +250,6 @@ mod tests {
         let k = KFold { n_splits: 2 };
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 22);
         let train_test_splits = k.split(&x);
-        print!("{:?}", &train_test_splits);
 
         assert_eq!(train_test_splits[0].1, (0..11).collect::<Vec<usize>>());
         assert_eq!(train_test_splits[0].0, (11..22).collect::<Vec<usize>>());

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -138,7 +138,7 @@ trait BaseKFold {
 
 }
 
-struct KFold {
+pub struct KFold {
     n_splits: i32,
     shuffle: bool,
     random_state: i32, 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -109,7 +109,7 @@ pub struct KFold {
 impl BaseKFold for KFold {
     fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>> {
         // number of samples (rows) in the matrix
-        let n_samples: usize = x.shape().1;
+        let n_samples: usize = x.shape().0;
 
         // initialise indices
         let indices: Vec<usize> = (0..n_samples).collect();
@@ -148,21 +148,9 @@ impl BaseKFold for KFold {
         return return_values;
     }
 
-#[test]
-    fn numpy_parity_test() {
-        let k = KFold { n_splits: 3 };
-        let x: DenseMatrix<f64> = DenseMatrix::rand(10, 4);
-        let expected: Vec<(Vec<usize>, Vec<usize>)> = vec!(
-            (vec!(4, 5, 6, 7, 8, 9), vec!(0, 1, 2, 3)),
-            (vec!(0, 1, 2, 3, 7, 8, 9), vec!(4, 5, 6)),
-            (vec!(0, 1, 2, 3, 4, 5, 6), vec!(7, 8, 9))
-        );
-        for ((train, test), (expected_train, expected_test)) in k.split(&x).into_iter().zip(expected) {
-            assert_eq!(test, expected_test);
-            assert_eq!(train, expected_train);
-        }        
-    }
-        let n_samples: usize = x.shape().1;
+    fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)> {
+        let n_samples: usize = x.shape().0;
+        println!("{:?}", n_samples);
         let indices: Vec<usize> = (0..n_samples).collect();
 
         let mut return_values: Vec<(Vec<usize>, Vec<usize>)> =
@@ -217,7 +205,7 @@ mod tests {
     #[test]
     fn run_kfold_return_test_indices_simple() {
         let k = KFold { n_splits: 3 };
-        let x: DenseMatrix<f64> = DenseMatrix::rand(100, 33);
+        let x: DenseMatrix<f64> = DenseMatrix::rand(33, 100);
         let test_indices = k.test_indices(&x);
 
         assert_eq!(test_indices[0], (0..11).collect::<Vec<usize>>());
@@ -228,7 +216,7 @@ mod tests {
     #[test]
     fn run_kfold_return_test_indices_odd() {
         let k = KFold { n_splits: 3 };
-        let x: DenseMatrix<f64> = DenseMatrix::rand(100, 34);
+        let x: DenseMatrix<f64> = DenseMatrix::rand(34, 100);
         let test_indices = k.test_indices(&x);
 
         assert_eq!(test_indices[0], (0..12).collect::<Vec<usize>>());
@@ -239,7 +227,7 @@ mod tests {
     #[test]
     fn run_kfold_return_test_mask_simple() {
         let k = KFold { n_splits: 2 };
-        let x: DenseMatrix<f64> = DenseMatrix::rand(100, 22);
+        let x: DenseMatrix<f64> = DenseMatrix::rand(22, 100);
         let test_masks = k.test_masks(&x);
 
         for t in &test_masks[0][0..11] {
@@ -261,12 +249,29 @@ mod tests {
     #[test]
     fn run_kfold_return_split_simple() {
         let k = KFold { n_splits: 2 };
-        let x: DenseMatrix<f64> = DenseMatrix::rand(100, 22);
+        let x: DenseMatrix<f64> = DenseMatrix::rand(22, 100);
         let train_test_splits = k.split(&x);
 
         assert_eq!(train_test_splits[0].1, (0..11).collect::<Vec<usize>>());
         assert_eq!(train_test_splits[0].0, (11..22).collect::<Vec<usize>>());
         assert_eq!(train_test_splits[1].0, (0..11).collect::<Vec<usize>>());
         assert_eq!(train_test_splits[1].1, (11..22).collect::<Vec<usize>>());
+    }
+
+    #[test]
+    fn numpy_parity_test() {
+        let k = KFold { n_splits: 3 };
+        let x: DenseMatrix<f64> = DenseMatrix::rand(10, 4);
+        let expected: Vec<(Vec<usize>, Vec<usize>)> = vec![
+            (vec![4, 5, 6, 7, 8, 9], vec![0, 1, 2, 3]),
+            (vec![0, 1, 2, 3, 7, 8, 9], vec![4, 5, 6]),
+            (vec![0, 1, 2, 3, 4, 5, 6], vec![7, 8, 9]),
+        ];
+        for ((train, test), (expected_train, expected_test)) in
+            k.split(&x).into_iter().zip(expected)
+        {
+            assert_eq!(test, expected_test);
+            assert_eq!(train, expected_train);
+        }
     }
 }

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -81,6 +81,105 @@ pub fn train_test_split<T: RealNumber, M: Matrix<T>>(
     (x_train, x_test, y_train, y_test)
 }
 
+
+///
+/// KFold Cross-Validation
+///
+/// Entities involved in the KFold procedure:
+///     * a dataset
+///     * a number k of groups (k-folds)
+/// 
+/// Procedure in `cross_validate()`: 
+///   1. Shuffle the dataset randomly.
+///   2. Split the dataset into k groups
+///   3. For each unique group:
+///         1. Take the group as a hold out or test data set
+///         2. Take the remaining groups as a training data set
+///         3. Fit a model on the training set and evaluate it on the test set
+///         4. Retain the evaluation score and discard the model
+///   4. Summarize the skill of the model using the sample of model evaluation scores
+trait BaseKFold {
+    /// Returns integer indices corresponding to test sets
+    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<usize>;
+
+    // /// Return matrix corresponding to test sets
+    // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<&M>;
+
+    // /// Return a tuple containing the the training set indices for that split and
+    // /// the testing set indices for that split.
+    // fn split<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<(Vec<usize>, Vec<usize>)>;
+}
+
+/// An implementation of KFold
+pub struct KFold {
+    n_splits: i32,
+    // TODO: to be implemented later
+    // shuffle: bool,
+    // random_state: i32, 
+}
+
+impl BaseKFold for KFold {
+    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<usize> {
+        // n_samples = _num_samples(X)  # number of sample in an array-like
+        let n_samples: usize = x.get_row_as_vec(0 as usize).len();
+        println!("n {:?}", &n_samples);
+
+        // indices = np.arange(n_samples)  # an iterator of size len(x)
+        let indices: Vec<usize> = (0..n_samples).collect();
+        println!("starting indices{:?}", &indices);
+
+        //  Return a new array of given shape n_split, filled with each element of n_samples divided by n_splits.
+        // fold_sizes = np.full(n_splits, n_samples // n_splits, dtype=int)
+        let mut fold_sizes = vec![n_samples / self.n_splits as usize; self.n_splits as usize];
+        println!("fold size {:?}", &fold_sizes);
+
+        // fold_sizes[:n_samples % n_splits] += 1
+        for i in 0..(n_samples % self.n_splits as usize) {
+            fold_sizes[i] = fold_sizes[i] + 1;
+        }
+        println!("fold size after correction{:?}", &fold_sizes);
+
+        let mut return_values: Vec<usize> = Vec::new();
+        let mut current: usize = 0;
+        for fold_size in fold_sizes {
+            let stop = current + fold_size;
+            println!("current, stop {:?}, {:?}", &current, &stop);
+            return_values.extend_from_slice(
+                &indices[current..stop].to_vec()
+            );
+            println!("loop {:?}", &return_values);
+            current = stop
+        }
+        
+        return return_values;
+
+    }
+
+    // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<&M> {
+    //     // Python implementation
+    //     // for test_index in self._iter_test_indices(X, y, groups):
+    //     //     test_mask = np.zeros(_num_samples(X), dtype=bool)
+    //     //     test_mask[test_index] = True
+    //     //     yield test_mask
+    //     let tmp = vec![&M::zeros(2, 2)];
+    //     return tmp;
+
+    // }
+
+    // fn split<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<(Vec<usize>, Vec<usize>)> {
+    //     // Python implementation
+    //     // X, y, groups = indexable(X, y, groups)
+    //     // indices = np.arange(_num_samples(X))  // an iterator of len(x)
+    //     // for test_index in self._iter_test_masks(X, y, groups):
+    //     //     train_index = indices[np.logical_not(test_index)]
+    //     //     test_index = indices[test_index]
+    //     //     yield train_index, test_index
+    //     let tmp = vec![(vec![0, 1], vec![0, 1])];
+    //     return tmp;
+    // }
+}
+
+
 #[cfg(test)]
 mod tests {
 
@@ -106,44 +205,28 @@ mod tests {
         assert_eq!(x_train.shape().0, y_train.len());
         assert_eq!(x_test.shape().0, y_test.len());
     }
-}
 
+    #[test]
+    fn run_kfold_return_test_indices_simple() {
+        let k = KFold { n_splits: 3};
 
-///
-/// KFold Cross-Validation
-///
-/// Entities involved in the KFold procedure:
-///     * a dataset
-///     * a number k of groups (k-folds)
-/// 
-/// Procedure in `cross_validate()`: 
-///   1. Shuffle the dataset randomly.
-///   2. Split the dataset into k groups
-///   3. For each unique group:
-///         1. Take the group as a hold out or test data set
-///         2. Take the remaining groups as a training data set
-///         3. Fit a model on the training set and evaluate it on the test set
-///         4. Retain the evaluation score and discard the model
-///   4. Summarize the skill of the model using the sample of model evaluation scores
-pub trait BaseKFold {
-    /// Return a tuple containing the the training set indices for that split and
-    /// the testing set indices for that split.
-    fn split(&self, X: Matrix) -> Iterator< Item = Tuple(ndarray::ArrayBase, ndarray::ArrayBase)>;
+        let x: DenseMatrix<f64> = DenseMatrix::rand(33, 33);
 
-    /// Returns integer indices corresponding to test sets
-    fn test_indices(&self, X: Matrix) -> Iterator< Item = i32>;
+        let test_indices = k.test_indices(&x);
 
-    /// Return matrix corresponding to test sets
-    fn test_matrices(&self, X: Matrix) -> Iterator< Item = Matrix>;
+        println!("{:?}", &test_indices);
+        assert_eq!(test_indices, (0..33).collect::<Vec<usize>>())
+    }
 
-}
+    #[test]
+    fn run_kfold_return_test_indices_odd() {
+        let k = KFold { n_splits: 3};
 
-pub struct KFold {
-    n_splits: i32,
-    shuffle: bool,
-    random_state: i32, 
-}
+        let x: DenseMatrix<f64> = DenseMatrix::rand(34, 34);
 
-impl BaseKFold for KFold {
-    ...
+        let test_indices = k.test_indices(&x);
+
+        println!("{:?}", &test_indices);
+        assert_eq!(test_indices, (0..34).collect::<Vec<usize>>())
+    }
 }

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -125,7 +125,7 @@ mod tests {
 ///         3. Fit a model on the training set and evaluate it on the test set
 ///         4. Retain the evaluation score and discard the model
 ///   4. Summarize the skill of the model using the sample of model evaluation scores
-trait BaseKFold {
+pub trait BaseKFold {
     /// Return a tuple containing the the training set indices for that split and
     /// the testing set indices for that split.
     fn split(&self, X: Matrix) -> Iterator< Item = Tuple(ndarray::ArrayBase, ndarray::ArrayBase)>;

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -191,7 +191,7 @@ impl BaseKFold for KFold {
                 .collect::<Vec<usize>>(); // filter tests indices out according to mask
             return_values.push((train_index, test_index))
         }
-        return return_values;
+        return_values
     }
 }
 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -148,7 +148,20 @@ impl BaseKFold for KFold {
         return return_values;
     }
 
-    fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)> {
+#[test]
+    fn numpy_parity_test() {
+        let k = KFold { n_splits: 3 };
+        let x: DenseMatrix<f64> = DenseMatrix::rand(10, 4);
+        let expected: Vec<(Vec<usize>, Vec<usize>)> = vec!(
+            (vec!(4, 5, 6, 7, 8, 9), vec!(0, 1, 2, 3)),
+            (vec!(0, 1, 2, 3, 7, 8, 9), vec!(4, 5, 6)),
+            (vec!(0, 1, 2, 3, 4, 5, 6), vec!(7, 8, 9))
+        );
+        for ((train, test), (expected_train, expected_test)) in k.split(&x).into_iter().zip(expected) {
+            assert_eq!(test, expected_test);
+            assert_eq!(train, expected_train);
+        }        
+    }
         let n_samples: usize = x.shape().1;
         let indices: Vec<usize> = (0..n_samples).collect();
 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -100,7 +100,7 @@ pub fn train_test_split<T: RealNumber, M: Matrix<T>>(
 ///   4. Summarize the skill of the model using the sample of model evaluation scores
 trait BaseKFold {
     /// Returns integer indices corresponding to test sets
-    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<usize>;
+    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>>;
 
     // /// Return matrix corresponding to test sets
     // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<&M>;
@@ -119,7 +119,7 @@ pub struct KFold {
 }
 
 impl BaseKFold for KFold {
-    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<usize> {
+    fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>> {
         // n_samples = _num_samples(X)  # number of sample in an array-like
         let n_samples: usize = x.get_row_as_vec(0 as usize).len();
         println!("n {:?}", &n_samples);
@@ -139,13 +139,13 @@ impl BaseKFold for KFold {
         }
         println!("fold size after correction{:?}", &fold_sizes);
 
-        let mut return_values: Vec<usize> = Vec::new();
+        let mut return_values: Vec<Vec<usize>> = Vec::new();
         let mut current: usize = 0;
         for fold_size in fold_sizes {
             let stop = current + fold_size;
             println!("current, stop {:?}, {:?}", &current, &stop);
-            return_values.extend_from_slice(
-                &indices[current..stop].to_vec()
+            return_values.push(
+                indices[current..stop].to_vec()
             );
             println!("loop {:?}", &return_values);
             current = stop
@@ -215,7 +215,9 @@ mod tests {
         let test_indices = k.test_indices(&x);
 
         println!("{:?}", &test_indices);
-        assert_eq!(test_indices, (0..33).collect::<Vec<usize>>())
+        assert_eq!(test_indices[0], (0..11).collect::<Vec<usize>>());
+        assert_eq!(test_indices[1], (11..22).collect::<Vec<usize>>());
+        assert_eq!(test_indices[2], (22..33).collect::<Vec<usize>>());
     }
 
     #[test]
@@ -227,6 +229,8 @@ mod tests {
         let test_indices = k.test_indices(&x);
 
         println!("{:?}", &test_indices);
-        assert_eq!(test_indices, (0..34).collect::<Vec<usize>>())
+        assert_eq!(test_indices[0], (0..12).collect::<Vec<usize>>());
+        assert_eq!(test_indices[1], (12..23).collect::<Vec<usize>>());
+        assert_eq!(test_indices[2], (23..34).collect::<Vec<usize>>());
     }
 }

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -130,9 +130,6 @@ impl BaseKFold for KFold {
         if self.shuffle == true {
             indices.shuffle(&mut thread_rng());
         }
-
-        let indices = indices;
-
         //  return a new array of given shape n_split, filled with each element of n_samples divided by n_splits.
         let mut fold_sizes = vec![n_samples / self.n_splits as usize; self.n_splits as usize];
 
@@ -150,7 +147,6 @@ impl BaseKFold for KFold {
             current = stop
         }
 
-        let return_values = return_values;
         return_values
     }
 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -165,7 +165,7 @@ impl BaseKFold for KFold {
             }
             return_values.push(test_mask);
         }
-        return return_values;
+        return_values
     }
 
     fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)> {

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -151,7 +151,7 @@ impl BaseKFold for KFold {
         }
 
         let return_values = return_values;
-        return return_values;
+        return_values
     }
 
     fn test_masks<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<bool>> {

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -81,23 +81,9 @@ pub fn train_test_split<T: RealNumber, M: Matrix<T>>(
     (x_train, x_test, y_train, y_test)
 }
 
-
 ///
 /// KFold Cross-Validation
 ///
-/// Entities involved in the KFold procedure:
-///     * a dataset
-///     * a number k of groups (k-folds)
-/// 
-/// Procedure in `cross_validate()`: 
-///   1. Shuffle the dataset randomly.
-///   2. Split the dataset into k groups
-///   3. For each unique group:
-///         1. Take the group as a hold out or test data set
-///         2. Take the remaining groups as a training data set
-///         3. Fit a model on the training set and evaluate it on the test set
-///         4. Retain the evaluation score and discard the model
-///   4. Summarize the skill of the model using the sample of model evaluation scores
 trait BaseKFold {
     /// Returns integer indices corresponding to test sets
     fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>>;
@@ -110,12 +96,14 @@ trait BaseKFold {
     fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)>;
 }
 
+///
 /// An implementation of KFold
+///
 pub struct KFold {
-    n_splits: i32,  // cannot exceed std::usize::MAX
-    // TODO: to be implemented later
-    // shuffle: bool,
-    // random_state: i32, 
+    n_splits: i32, // cannot exceed std::usize::MAX
+                   // TODO: to be implemented later
+                   // shuffle: bool,
+                   // random_state: i32,
 }
 
 impl BaseKFold for KFold {
@@ -144,15 +132,12 @@ impl BaseKFold for KFold {
         for fold_size in fold_sizes.drain(..) {
             let stop = current + fold_size;
             println!("current, stop {:?}, {:?}", &current, &stop);
-            return_values.push(
-                indices[current..stop].to_vec()
-            );
+            return_values.push(indices[current..stop].to_vec());
             println!("loop {:?}", &return_values);
             current = stop
         }
-        
-        return return_values;
 
+        return return_values;
     }
 
     fn test_masks<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<bool>> {
@@ -162,7 +147,7 @@ impl BaseKFold for KFold {
             let mut test_mask = vec![false; x.shape().0];
             // set mask's indices to true according to test indices
             for i in test_index {
-                test_mask[i] = true;  // can be implemented with map()
+                test_mask[i] = true; // can be implemented with map()
             }
             return_values.push(test_mask);
         }
@@ -174,28 +159,28 @@ impl BaseKFold for KFold {
         let indices: Vec<usize> = (0..n_samples).collect();
         println!("starting indices{:?}", &indices);
 
-        let mut return_values: Vec<(Vec<usize>, Vec<usize>)> = Vec::with_capacity(
-            self.n_splits as usize
-        );  // TODO: init nested vecs with capacities by getting the length of test_index vecs
+        let mut return_values: Vec<(Vec<usize>, Vec<usize>)> =
+            Vec::with_capacity(self.n_splits as usize); // TODO: init nested vecs with capacities by getting the length of test_index vecs
 
         for test_index in self.test_masks(x).drain(..) {
-            let train_index = indices.clone().iter().enumerate()
+            let train_index = indices
+                .clone()
+                .iter()
+                .enumerate()
                 .filter(|&(idx, _)| test_index[idx] == false)
                 .map(|(idx, _)| idx)
-                .collect::<Vec<usize>>();  // filter train indices out according to mask
-            let test_index = indices.iter().enumerate()
+                .collect::<Vec<usize>>(); // filter train indices out according to mask
+            let test_index = indices
+                .iter()
+                .enumerate()
                 .filter(|&(idx, _)| test_index[idx] == true)
                 .map(|(idx, _)| idx)
-                .collect::<Vec<usize>>();  // filter tests indices out according to mask
-            return_values.push(
-                (train_index, test_index)
-            )
-            
+                .collect::<Vec<usize>>(); // filter tests indices out according to mask
+            return_values.push((train_index, test_index))
         }
         return return_values;
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -225,7 +210,7 @@ mod tests {
 
     #[test]
     fn run_kfold_return_test_indices_simple() {
-        let k = KFold { n_splits: 3};
+        let k = KFold { n_splits: 3 };
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 33);
         let test_indices = k.test_indices(&x);
 
@@ -237,7 +222,7 @@ mod tests {
 
     #[test]
     fn run_kfold_return_test_indices_odd() {
-        let k = KFold { n_splits: 3};
+        let k = KFold { n_splits: 3 };
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 34);
         let test_indices = k.test_indices(&x);
 
@@ -249,7 +234,7 @@ mod tests {
 
     #[test]
     fn run_kfold_return_test_mask_simple() {
-        let k = KFold { n_splits: 2};
+        let k = KFold { n_splits: 2 };
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 22);
         let test_masks = k.test_masks(&x);
 
@@ -270,7 +255,7 @@ mod tests {
 
     #[test]
     fn run_kfold_return_split_simple() {
-        let k = KFold { n_splits: 2};
+        let k = KFold { n_splits: 2 };
         let x: DenseMatrix<f64> = DenseMatrix::rand(100, 22);
         let train_test_splits = k.split(&x);
         print!("{:?}", &train_test_splits);

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -150,7 +150,6 @@ impl BaseKFold for KFold {
 
     fn split<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<(Vec<usize>, Vec<usize>)> {
         let n_samples: usize = x.shape().0;
-        println!("{:?}", n_samples);
         let indices: Vec<usize> = (0..n_samples).collect();
 
         let mut return_values: Vec<(Vec<usize>, Vec<usize>)> =

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -107,3 +107,43 @@ mod tests {
         assert_eq!(x_test.shape().0, y_test.len());
     }
 }
+
+
+///
+/// KFold Cross-Validation
+///
+/// Entities involved in the KFold procedure:
+///     * a dataset
+///     * a number k of groups (k-folds)
+/// 
+/// Procedure in `cross_validate()`: 
+///   1. Shuffle the dataset randomly.
+///   2. Split the dataset into k groups
+///   3. For each unique group:
+///         1. Take the group as a hold out or test data set
+///         2. Take the remaining groups as a training data set
+///         3. Fit a model on the training set and evaluate it on the test set
+///         4. Retain the evaluation score and discard the model
+///   4. Summarize the skill of the model using the sample of model evaluation scores
+trait BaseKFold {
+    /// Return a tuple containing the the training set indices for that split and
+    /// the testing set indices for that split.
+    fn split(&self, X: Matrix) -> Iterator< Item = Tuple(ndarray::ArrayBase, ndarray::ArrayBase)>;
+
+    /// Returns integer indices corresponding to test sets
+    fn test_indices(&self, X: Matrix) -> Iterator< Item = i32>;
+
+    /// Return matrix corresponding to test sets
+    fn test_matrices(&self, X: Matrix) -> Iterator< Item = Matrix>;
+
+}
+
+struct KFold {
+    n_splits: i32,
+    shuffle: bool,
+    random_state: i32, 
+}
+
+impl BaseKFold for KFold {
+    ...
+}

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -127,10 +127,11 @@ impl BaseKFold for KFold {
 
         // initialise indices
         let mut indices: Vec<usize> = (0..n_samples).collect();
-
         if self.shuffle == true {
             indices.shuffle(&mut thread_rng());
         }
+
+        let indices = indices;
 
         //  return a new array of given shape n_split, filled with each element of n_samples divided by n_splits.
         let mut fold_sizes = vec![n_samples / self.n_splits as usize; self.n_splits as usize];
@@ -149,7 +150,7 @@ impl BaseKFold for KFold {
             current = stop
         }
 
-        // let return_values = return_values;
+        let return_values = return_values;
         return return_values;
     }
 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -102,7 +102,7 @@ pub trait BaseKFold {
 /// An implementation of KFold
 ///
 pub struct KFold {
-    n_splits: i32, // cannot exceed std::usize::MAX
+    n_splits: usize, // cannot exceed std::usize::MAX
     shuffle: bool,
     // TODO: to be implemented later
     // random_state: i32,
@@ -111,7 +111,7 @@ pub struct KFold {
 impl Default for KFold {
     fn default() -> KFold {
         KFold {
-            n_splits: 3i32,
+            n_splits: 3 as usize,
             shuffle: true,
         }
     }
@@ -131,15 +131,15 @@ impl BaseKFold for KFold {
             indices.shuffle(&mut thread_rng());
         }
         //  return a new array of given shape n_split, filled with each element of n_samples divided by n_splits.
-        let mut fold_sizes = vec![n_samples / self.n_splits as usize; self.n_splits as usize];
+        let mut fold_sizes = vec![n_samples / self.n_splits; self.n_splits];
 
         // increment by one if odd
-        for i in 0..(n_samples % self.n_splits as usize) {
+        for i in 0..(n_samples % self.n_splits) {
             fold_sizes[i] = fold_sizes[i] + 1;
         }
 
         // generate the right array of arrays for test indices
-        let mut return_values: Vec<Vec<usize>> = Vec::with_capacity(self.n_splits as usize);
+        let mut return_values: Vec<Vec<usize>> = Vec::with_capacity(self.n_splits);
         let mut current: usize = 0;
         for fold_size in fold_sizes.drain(..) {
             let stop = current + fold_size;
@@ -151,7 +151,7 @@ impl BaseKFold for KFold {
     }
 
     fn test_masks<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<bool>> {
-        let mut return_values: Vec<Vec<bool>> = Vec::with_capacity(self.n_splits as usize);
+        let mut return_values: Vec<Vec<bool>> = Vec::with_capacity(self.n_splits);
         for test_index in self.test_indices(x).drain(..) {
             // init mask
             let mut test_mask = vec![false; x.shape().0];
@@ -168,8 +168,7 @@ impl BaseKFold for KFold {
         let n_samples: usize = x.shape().0;
         let indices: Vec<usize> = (0..n_samples).collect();
 
-        let mut return_values: Vec<(Vec<usize>, Vec<usize>)> =
-            Vec::with_capacity(self.n_splits as usize); // TODO: init nested vecs with capacities by getting the length of test_index vecs
+        let mut return_values: Vec<(Vec<usize>, Vec<usize>)> = Vec::with_capacity(self.n_splits); // TODO: init nested vecs with capacities by getting the length of test_index vecs
 
         for test_index in self.test_masks(x).drain(..) {
             let train_index = indices

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -84,7 +84,7 @@ pub fn train_test_split<T: RealNumber, M: Matrix<T>>(
 ///
 /// KFold Cross-Validation
 ///
-trait BaseKFold {
+pub trait BaseKFold {
     /// Returns integer indices corresponding to test sets
     fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>>;
 

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -121,7 +121,7 @@ pub struct KFold {
 impl BaseKFold for KFold {
     fn test_indices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<Vec<usize>> {
         // n_samples = _num_samples(X)  # number of sample in an array-like
-        let n_samples: usize = x.get_row_as_vec(0 as usize).len();
+        let n_samples: usize = x.shape().1;
         println!("n {:?}", &n_samples);
 
         // indices = np.arange(n_samples)  # an iterator of size len(x)
@@ -157,13 +157,14 @@ impl BaseKFold for KFold {
 
     // fn test_matrices<T: RealNumber, M: Matrix<T>>(&self, x: &M) -> Vec<&M> {
     //     // Python implementation
-    //     // for test_index in self._iter_test_indices(X, y, groups):
-    //     //     test_mask = np.zeros(_num_samples(X), dtype=bool)
-    //     //     test_mask[test_index] = True
-    //     //     yield test_mask
+    //     for test_index in self.test_indices(x) {
+    //         // test_mask = np.zeros(_num_samples(X), dtype=bool)
+    //         let test_mask = M::zeros(x.shape().0, x.shape().1);
+    //         test_mask[test_index] = True
+    //         yield test_mask
+    //     }
     //     let tmp = vec![&M::zeros(2, 2)];
     //     return tmp;
-
     // }
 
     // fn split<T: RealNumber, M: Matrix<T>>(&self, X: &M) -> Vec<(Vec<usize>, Vec<usize>)> {


### PR DESCRIPTION
#5 

...
* implement `test_indices`, `test_matrices`, `split` to accept a matrix and return a `Vec`
* improve allocation (?)
* make all three to return an iterator (?)