### PR TITLE
Allow KNN with k=1

### DIFF
--- a/src/algorithm/sort/heap_select.rs
+++ b/src/algorithm/sort/heap_select.rs
@@ -41,6 +41,9 @@ impl<'a, T: PartialOrd + Debug> HeapSelection<T> {
 
     pub fn heapify(&mut self) {
         let n = self.heap.len();
+        if n <= 1 {
+            return;
+        }
         for i in (0..=(n / 2 - 1)).rev() {
             self.sift_down(i, n - 1);
         }

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -116,9 +116,9 @@ impl<T: RealNumber, D: Distance<Vec<T>, T>> KNNRegressor<T, D> {
             )));
         }
 
-        if parameters.k <= 1 {
+        if parameters.k < 1 {
             return Err(Failed::fit(&format!(
-                "k should be > 1, k=[{}]",
+                "k should be > 0, k=[{}]",
                 parameters.k
             )));
         }


### PR DESCRIPTION
Hi, thanks for this cool library.

I tried to use the KNNRegressor with k = 1: 
```rust
    let knn = KNNRegressor::fit(
        &X,
        &Y,
        Distances::euclidian(),
        KNNRegressorParameters {
            algorithm: KNNAlgorithmName::CoverTree,
            k: 1,
            weight: KNNWeightFunction::Uniform,
        },
    )?;
```
But it failed due to https://github.com/smartcorelib/smartcore/blob/a2588f6f459b6138fb40aa2b29dd456478e5f29d/src/neighbors/knn_regressor.rs#L119

I cloned this project and changed that line and it worked fine with my dataset! 

Is there something that I can do to add that support here? I also tried to run that with LinearSearch algorithm instead of CoverTree algorithm in

```rust
    let knn = KNNRegressor::fit(
        &X,
        &Y,
        Distances::euclidian(),
        KNNRegressorParameters {
            algorithm: KNNAlgorithmName::LinearSearch,
            k: 1,
            weight: KNNWeightFunction::Uniform,
        },
    )?;
```
But it failed due to 
```
thread 'main' panicked at 'attempt to subtract with overflow', /home/user/rust/smartcore/src/algorithm/sort/heap_select.rs:44:23
```
So I changed the heapify function of HeapSelect to handle that case. Is this something that it is worth to merge? or there is another reason to add the restriction to k>1?

