### PR TITLE
Add capability to convert a slice to a BaseVector

### DIFF
--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -83,6 +83,21 @@ pub trait BaseVector<T: RealNumber>: Clone + Debug {
         self.len() == 0
     }
 
+    /// Create a new vector from a &[T]
+    /// ```
+    /// use smartcore::linalg::naive::dense_matrix::*;
+    /// let slice: &[f64] = &[0., 0.5, 2., 3., 4.];
+    /// let a: Vec<f64> = BaseVector::from_slice(slice);
+    /// assert_eq!(a, vec![0., 0.5, 2., 3., 4.]);
+    /// ```
+    fn from_slice(f: &[T]) -> Self {
+        let mut v = Self::zeros(f.len());
+        for (i, elem) in f.iter().enumerate() {
+            v.set(i, *elem);
+        }
+        v
+    }
+
     /// Return a vector with the elements of the one-dimensional array.
     fn to_vec(&self) -> Vec<T>;
 

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -86,11 +86,11 @@ pub trait BaseVector<T: RealNumber>: Clone + Debug {
     /// Create a new vector from a &[T]
     /// ```
     /// use smartcore::linalg::naive::dense_matrix::*;
-    /// let slice: &[f64] = &[0., 0.5, 2., 3., 4.];
-    /// let a: Vec<f64> = BaseVector::from_slice(slice);
-    /// assert_eq!(a, vec![0., 0.5, 2., 3., 4.]);
+    /// let a: [f64; 5] = [0., 0.5, 2., 3., 4.];
+    /// let v: Vec<f64> = BaseVector::from_array(&a);
+    /// assert_eq!(v, vec![0., 0.5, 2., 3., 4.]);
     /// ```
-    fn from_slice(f: &[T]) -> Self {
+    fn from_array(f: &[T]) -> Self {
         let mut v = Self::zeros(f.len());
         for (i, elem) in f.iter().enumerate() {
             v.set(i, *elem);

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 
 use crate::linalg::BaseVector;
 pub trait RealNumberVector<T: RealNumber> {
-    fn unique(&self) -> (Vec<T>, Vec<usize>);
+    fn unique_with_indices(&self) -> (Vec<T>, Vec<usize>);
 }
 
 impl<T: RealNumber, V: BaseVector<T>> RealNumberVector<T> for V {
-    fn unique(&self) -> (Vec<T>, Vec<usize>) {
+    fn unique_with_indices(&self) -> (Vec<T>, Vec<usize>) {
         let mut unique = self.to_vec();
         unique.sort_by(|a, b| a.partial_cmp(b).unwrap());
         unique.dedup();
@@ -28,14 +28,14 @@ impl<T: RealNumber, V: BaseVector<T>> RealNumberVector<T> for V {
 
 #[cfg(test)]
 mod tests {
-    use super::RealNumberVector;
+    use super::*;
 
     #[test]
-    fn unique() {
+    fn unique_with_indices() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];
         assert_eq!(
             (vec!(0.0, 1.0, 2.0, 4.0), vec!(0, 0, 1, 1, 2, 0, 3)),
-            v1.unique()
+            v1.unique_with_indices()
         );
     }
 }

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -1,13 +1,14 @@
 use crate::math::num::RealNumber;
 use std::collections::HashMap;
 
+use crate::linalg::BaseVector;
 pub trait RealNumberVector<T: RealNumber> {
     fn unique(&self) -> (Vec<T>, Vec<usize>);
 }
 
-impl<T: RealNumber> RealNumberVector<T> for Vec<T> {
+impl<T: RealNumber, V: BaseVector<T>> RealNumberVector<T> for V {
     fn unique(&self) -> (Vec<T>, Vec<usize>) {
-        let mut unique = self.clone();
+        let mut unique = self.to_vec();
         unique.sort_by(|a, b| a.partial_cmp(b).unwrap());
         unique.dedup();
 
@@ -17,8 +18,8 @@ impl<T: RealNumber> RealNumberVector<T> for Vec<T> {
         }
 
         let mut unique_index = Vec::with_capacity(self.len());
-        for e in self {
-            unique_index.push(index[&e.to_i64().unwrap()]);
+        for idx in 0..self.len() {
+            unique_index.push(index[&self.get(idx).to_i64().unwrap()]);
         }
 
         (unique, unique_index)
@@ -27,7 +28,7 @@ impl<T: RealNumber> RealNumberVector<T> for Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::RealNumberVector;
 
     #[test]
     fn unique() {

--- a/src/metrics/cluster_helpers.rs
+++ b/src/metrics/cluster_helpers.rs
@@ -7,8 +7,8 @@ pub fn contingency_matrix<T: RealNumber>(
     labels_true: &Vec<T>,
     labels_pred: &Vec<T>,
 ) -> Vec<Vec<usize>> {
-    let (classes, class_idx) = labels_true.unique();
-    let (clusters, cluster_idx) = labels_pred.unique();
+    let (classes, class_idx) = labels_true.unique_with_indices();
+    let (clusters, cluster_idx) = labels_pred.unique_with_indices();
 
     let mut contingency_matrix = Vec::with_capacity(classes.len());
 

--- a/src/naive_bayes/mod.rs
+++ b/src/naive_bayes/mod.rs
@@ -58,7 +58,7 @@ impl<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> BaseNaiveBayes<T, M, 
                 *prediction
             })
             .collect::<Vec<T>>();
-        let y_hat = M::RowVector::from_slice(&predictions);
+        let y_hat = M::RowVector::from_array(&predictions);
         Ok(y_hat)
     }
 }

--- a/src/naive_bayes/mod.rs
+++ b/src/naive_bayes/mod.rs
@@ -58,10 +58,7 @@ impl<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> BaseNaiveBayes<T, M, 
                 *prediction
             })
             .collect::<Vec<T>>();
-        let mut y_hat = M::RowVector::zeros(rows);
-        for (i, prediction) in predictions.iter().enumerate().take(rows) {
-            y_hat.set(i, *prediction);
-        }
+        let y_hat = M::RowVector::from_slice(&predictions);
         Ok(y_hat)
     }
 }


### PR DESCRIPTION
I wanted to implement a generic way to convert a Vec<T> to a BaseVector<T> but then I realized that I could do that as &[T] which fits in the &Vec<T> case.

I also changed the implementation of RealNumberVector over BaseVector instead of over Vec<T> so I can use that in the implementation of the other Naive Bayes classifiers without the need of creating a Vec<T> from the data. Everything should work at the same way. The only major concern there is that if  BaseVector  is on scope it would be necessary to call that at this way because it conflicts with the BaseVector unique function:

```rust
RealNumber::unique(v);
```