### PR TITLE
Change implementation of to_row_vector for nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ datasets = []
 
 [dependencies]
 ndarray = { version = "0.13", optional = true }
-nalgebra = { version = "0.22.0", optional = true }
+nalgebra = { version = "0.23.0", optional = true }
 num-traits = "0.2.12"
 num = "0.3.0"
 rand = "0.7.3"

--- a/src/linalg/naive/dense_matrix.rs
+++ b/src/linalg/naive/dense_matrix.rs
@@ -1065,6 +1065,12 @@ mod tests {
     }
 
     #[test]
+    fn col_matrix_to_row_vector() {
+        let m: DenseMatrix<f64> = BaseMatrix::zeros(10, 1);
+        assert_eq!(m.to_row_vector().len(), 10)
+    }
+
+    #[test]
     fn iter() {
         let vec = vec![1., 2., 3., 4., 5., 6.];
         let m = DenseMatrix::from_array(3, 2, &vec);

--- a/src/linalg/nalgebra_bindings.rs
+++ b/src/linalg/nalgebra_bindings.rs
@@ -185,14 +185,15 @@ impl<T: RealNumber + 'static> BaseVector<T> for MatrixMN<T, U1, Dynamic> {
 impl<T: RealNumber + Scalar + AddAssign + SubAssign + MulAssign + DivAssign + Sum + 'static>
     BaseMatrix<T> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>>
 {
-    type RowVector = MatrixMN<T, U1, Dynamic>;
+    type RowVector = RowDVector<T>;
 
     fn from_row_vector(vec: Self::RowVector) -> Self {
         Matrix::from_rows(&[vec])
     }
 
     fn to_row_vector(self) -> Self::RowVector {
-        self.row(0).into_owned()
+        let (nrows, ncols) = self.shape();
+        self.reshape_generic(U1, Dynamic::new(nrows * ncols))
     }
 
     fn get(&self, row: usize, col: usize) -> T {

--- a/src/linalg/nalgebra_bindings.rs
+++ b/src/linalg/nalgebra_bindings.rs
@@ -698,6 +698,12 @@ mod tests {
     }
 
     #[test]
+    fn col_matrix_to_row_vector() {
+        let m: DMatrix<f64> = BaseMatrix::zeros(10, 1);
+        assert_eq!(m.to_row_vector().len(), 10)
+    }
+
+    #[test]
     fn get_row_col_as_vec() {
         let m = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
 

--- a/src/linalg/ndarray_bindings.rs
+++ b/src/linalg/ndarray_bindings.rs
@@ -564,6 +564,12 @@ mod tests {
     }
 
     #[test]
+    fn col_matrix_to_row_vector() {
+        let m: Array2<f64> = BaseMatrix::zeros(10, 1);
+        assert_eq!(m.to_row_vector().len(), 10)
+    }
+
+    #[test]
     fn add_mut() {
         let mut a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
         let a2 = a1.clone();


### PR DESCRIPTION
Changing the implementation of to_row_vector in nalgebra. It is now a reshape to (1, number of elements).

It was necessary an upgrade of the nalgebra crate in order to be able to use `reshape_generic`.