### PR TITLE
fix: Update ndarray version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nalgebra-bindings = ["nalgebra"]
 datasets = []
 
 [dependencies]
-ndarray = { version = "0.13", optional = true }
+ndarray = { version = "0.14", optional = true }
 nalgebra = { version = "0.23.0", optional = true }
 num-traits = "0.2.12"
 num = "0.3.0"

--- a/src/linalg/ndarray_bindings.rs
+++ b/src/linalg/ndarray_bindings.rs
@@ -47,7 +47,7 @@ use std::ops::Range;
 use std::ops::SubAssign;
 
 use ndarray::ScalarOperand;
-use ndarray::{s, stack, Array, ArrayBase, Axis, Ix1, Ix2, OwnedRepr};
+use ndarray::{concatenate, s, Array, ArrayBase, Axis, Ix1, Ix2, OwnedRepr};
 
 use crate::linalg::cholesky::CholeskyDecomposableMatrix;
 use crate::linalg::evd::EVDDecomposableMatrix;
@@ -246,11 +246,11 @@ impl<T: RealNumber + ScalarOperand + AddAssign + SubAssign + MulAssign + DivAssi
     }
 
     fn h_stack(&self, other: &Self) -> Self {
-        stack(Axis(1), &[self.view(), other.view()]).unwrap()
+        concatenate(Axis(1), &[self.view(), other.view()]).unwrap()
     }
 
     fn v_stack(&self, other: &Self) -> Self {
-        stack(Axis(0), &[self.view(), other.view()]).unwrap()
+        concatenate(Axis(0), &[self.view(), other.view()]).unwrap()
     }
 
     fn matmul(&self, other: &Self) -> Self {


### PR DESCRIPTION
Use the last version of ndarray, a change was necessary due to a change in the API:

> The old function stack has been renamed to concatenate. A new function stack with numpy-like semantics have taken its place. Old usages of stack should change to use concatenate.

See in: https://github.com/rust-ndarray/ndarray/blob/master/RELEASES.md