### PR TITLE
feat: makes smartcore::error:FailedError non-exhaustive

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -12,6 +12,7 @@ pub struct Failed {
 }
 
 /// Type of error
+#[non_exhaustive]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum FailedError {
     /// Can't fit algorithm to data


### PR DESCRIPTION
Adds `non_exhaustive` attribute to crate::error::FailedError to indicate that this type may have more fields added in the future