### PR TITLE
feat: Add getters for naive bayes structs

### DIFF
--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -57,6 +57,8 @@ struct BernoulliNBDistribution<T: RealNumber> {
     class_priors: Vec<T>,
     /// probability of features per class
     feature_prob: Vec<Vec<T>>,
+    /// Number of features of each sample
+    n_features: usize,
 }
 
 impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for BernoulliNBDistribution<T> {
@@ -208,6 +210,7 @@ impl<T: RealNumber> BernoulliNBDistribution<T> {
             class_priors,
             class_count,
             feature_prob,
+            n_features,
         })
     }
 }
@@ -286,6 +289,11 @@ impl<T: RealNumber, M: Matrix<T>> BernoulliNB<T, M> {
     pub fn class_count(&self) -> &Vec<usize> {
         &self.inner.distribution.class_count
     }
+
+    /// Number of features of each sample
+    pub fn n_features(&self) -> usize {
+        self.inner.distribution.n_features
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +365,7 @@ mod tests {
 
         assert_eq!(bnb.classes(), &[0., 1., 2.]);
         assert_eq!(bnb.class_count(), &[7, 3, 5]);
+        assert_eq!(bnb.n_features(), 10);
 
         assert!(bnb
             .inner

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -213,7 +213,13 @@ impl<T: RealNumber> BernoulliNBDistribution<T> {
 
         for (row, class_index) in row_iter(x).zip(indices) {
             for (idx, row_i) in row.iter().enumerate().take(n_features) {
-                feature_in_class_counter[class_index][idx] += row_i.to_usize().unwrap();
+                feature_in_class_counter[class_index][idx] +=
+                    row_i.to_usize().ok_or_else(|| {
+                        Failed::fit(&format!(
+                            "Elements of the matrix should be 1.0 or 0.0 |found|=[{}]",
+                            row_i
+                        ))
+                    })?;
             }
         }
 

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -266,6 +266,12 @@ impl<T: RealNumber, M: Matrix<T>> BernoulliNB<T, M> {
             self.inner.predict(x)
         }
     }
+
+    /// Class labels known to the classifier.
+    /// Returns a vector of size n_classes.
+    pub fn classes(&self) -> &Vec<T> {
+        &self.inner.distribution.class_labels
+    }
 }
 
 #[cfg(test)]
@@ -334,6 +340,8 @@ mod tests {
         let bnb = BernoulliNB::fit(&x, &y, Default::default()).unwrap();
 
         let y_hat = bnb.predict(&x).unwrap();
+
+        assert_eq!(bnb.classes(), &[0., 1., 2.]);
 
         assert!(bnb
             .inner

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -76,7 +76,7 @@ impl<T: RealNumber> PartialEq for BernoulliNBDistribution<T> {
                 .iter()
                 .zip(other.feature_log_prob.iter())
             {
-                if a.approximate_eq(b, T::epsilon()) == false {
+                if !a.approximate_eq(b, T::epsilon()) {
                     return false;
                 }
             }

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -287,6 +287,12 @@ impl<T: RealNumber, M: Matrix<T>> CategoricalNB<T, M> {
     pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
         self.inner.predict(x)
     }
+
+    /// Class labels known to the classifier.
+    /// Returns a vector of size n_classes.
+    pub fn classes(&self) -> &Vec<T> {
+        &self.inner.distribution.class_labels
+    }
 }
 
 #[cfg(test)]
@@ -315,6 +321,9 @@ mod tests {
         let y = vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 1., 1., 1., 0.];
 
         let cnb = CategoricalNB::fit(&x, &y, Default::default()).unwrap();
+
+        assert_eq!(cnb.classes(), &[0., 1.]);
+
         let x_test = DenseMatrix::from_2d_array(&[&[0., 2., 1., 0.], &[2., 2., 0., 0.]]);
         let y_hat = cnb.predict(&x_test).unwrap();
         assert_eq!(y_hat, vec![0., 1.]);

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -47,6 +47,8 @@ struct CategoricalNBDistribution<T: RealNumber> {
     class_labels: Vec<T>,
     class_priors: Vec<T>,
     coefficients: Vec<Vec<Vec<T>>>,
+    /// Number of features of each sample
+    n_features: usize,
 }
 
 impl<T: RealNumber> PartialEq for CategoricalNBDistribution<T> {
@@ -216,6 +218,7 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
             class_labels,
             class_priors,
             coefficients,
+            n_features,
         })
     }
 }
@@ -302,6 +305,11 @@ impl<T: RealNumber, M: Matrix<T>> CategoricalNB<T, M> {
     pub fn class_count(&self) -> &Vec<usize> {
         &self.inner.distribution.class_count
     }
+
+    /// Number of features of each sample
+    pub fn n_features(&self) -> usize {
+        self.inner.distribution.n_features
+    }
 }
 
 #[cfg(test)]
@@ -333,6 +341,7 @@ mod tests {
 
         assert_eq!(cnb.classes(), &[0., 1.]);
         assert_eq!(cnb.class_count(), &[5, 9]);
+        assert_eq!(cnb.n_features(), 4);
 
         let x_test = DenseMatrix::from_2d_array(&[&[0., 2., 1., 0.], &[2., 2., 0., 0.]]);
         let y_hat = cnb.predict(&x_test).unwrap();

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -42,7 +42,7 @@ struct GaussianNBDistribution<T: RealNumber> {
     /// probability of each class.
     class_priors: Vec<T>,
     /// variance of each feature per class
-    sigma: Vec<Vec<T>>,
+    var: Vec<Vec<T>>,
     /// mean of each feature per class
     theta: Vec<Vec<T>>,
 }
@@ -57,18 +57,14 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for GaussianNBDistributio
     }
 
     fn log_likelihood(&self, class_index: usize, j: &M::RowVector) -> T {
-        if class_index < self.class_labels.len() {
-            let mut likelihood = T::zero();
-            for feature in 0..j.len() {
-                let value = j.get(feature);
-                let mean = self.theta[class_index][feature];
-                let variance = self.sigma[class_index][feature];
-                likelihood += self.calculate_log_probability(value, mean, variance);
-            }
-            likelihood
-        } else {
-            T::zero()
+        let mut likelihood = T::zero();
+        for feature in 0..j.len() {
+            let value = j.get(feature);
+            let mean = self.theta[class_index][feature];
+            let variance = self.var[class_index][feature];
+            likelihood += self.calculate_log_probability(value, mean, variance);
         }
+        likelihood
     }
 
     fn classes(&self) -> &Vec<T> {
@@ -157,7 +153,7 @@ impl<T: RealNumber> GaussianNBDistribution<T> {
             })
             .collect();
 
-        let (sigma, theta): (Vec<Vec<T>>, Vec<Vec<T>>) = subdataset
+        let (var, theta): (Vec<Vec<T>>, Vec<Vec<T>>) = subdataset
             .iter()
             .map(|data| (data.var(0), data.mean(0)))
             .unzip();
@@ -165,7 +161,7 @@ impl<T: RealNumber> GaussianNBDistribution<T> {
         Ok(Self {
             class_labels,
             class_priors,
-            sigma,
+            var,
             theta,
         })
     }
@@ -223,6 +219,30 @@ impl<T: RealNumber, M: Matrix<T>> GaussianNB<T, M> {
     pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
         self.inner.predict(x)
     }
+
+    /// Class labels known to the classifier.
+    /// Returns a vector of size n_classes.
+    pub fn classes(&self) -> &Vec<T> {
+        &self.inner.distribution.class_labels
+    }
+
+    /// Probability of each class
+    /// Returns a vector of size n_classes.
+    pub fn class_priors(&self) -> &Vec<T> {
+        &self.inner.distribution.class_priors
+    }
+
+    /// Mean of each feature per class
+    /// Returns a 2d vector of shape (n_classes, n_features).
+    pub fn theta(&self) -> &Vec<Vec<T>> {
+        &self.inner.distribution.theta
+    }
+
+    /// Variance of each feature per class
+    /// Returns a 2d vector of shape (n_classes, n_features).
+    pub fn var(&self) -> &Vec<Vec<T>> {
+        &self.inner.distribution.var
+    }
 }
 
 #[cfg(test)]
@@ -245,18 +265,21 @@ mod tests {
         let gnb = GaussianNB::fit(&x, &y, Default::default()).unwrap();
         let y_hat = gnb.predict(&x).unwrap();
         assert_eq!(y_hat, y);
+
+        assert_eq!(gnb.classes(), &[1., 2.]);
+
         assert_eq!(
-            gnb.inner.distribution.sigma,
+            gnb.var(),
             &[
                 &[0.666666666666667, 0.22222222222222232],
                 &[0.666666666666667, 0.22222222222222232]
             ]
         );
 
-        assert_eq!(gnb.inner.distribution.class_priors, &[0.5, 0.5]);
+        assert_eq!(gnb.class_priors(), &[0.5, 0.5]);
 
         assert_eq!(
-            gnb.inner.distribution.theta,
+            gnb.theta(),
             &[&[-2., -1.3333333333333333], &[2., 1.3333333333333333]]
         );
     }
@@ -277,7 +300,7 @@ mod tests {
         let parameters = GaussianNBParameters::default().with_priors(priors.clone());
         let gnb = GaussianNB::fit(&x, &y, parameters).unwrap();
 
-        assert_eq!(gnb.inner.distribution.class_priors, priors);
+        assert_eq!(gnb.class_priors(), &priors);
     }
 
     #[test]

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -176,7 +176,13 @@ impl<T: RealNumber> MultinomialNBDistribution<T> {
 
         for (row, class_index) in row_iter(x).zip(indices) {
             for (idx, row_i) in row.iter().enumerate().take(n_features) {
-                feature_in_class_counter[class_index][idx] += row_i.to_usize().unwrap();
+                feature_in_class_counter[class_index][idx] +=
+                    row_i.to_usize().ok_or_else(|| {
+                        Failed::fit(&format!(
+                            "Elements of the matrix should be convertible to usize |found|=[{}]",
+                            row_i
+                        ))
+                    })?;
             }
         }
 

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -55,6 +55,8 @@ struct MultinomialNBDistribution<T: RealNumber> {
     class_priors: Vec<T>,
     /// Empirical log probability of features given a class
     feature_log_prob: Vec<Vec<T>>,
+    /// Number of features of each sample
+    n_features: usize,
 }
 
 impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for MultinomialNBDistribution<T> {
@@ -192,6 +194,7 @@ impl<T: RealNumber> MultinomialNBDistribution<T> {
             class_labels,
             class_priors,
             feature_log_prob,
+            n_features,
         })
     }
 }
@@ -262,6 +265,11 @@ impl<T: RealNumber, M: Matrix<T>> MultinomialNB<T, M> {
     /// Returns a 2d vector of shape (n_classes, n_features)
     pub fn feature_log_prob(&self) -> &Vec<Vec<T>> {
         &self.inner.distribution.feature_log_prob
+    }
+
+    /// Number of features of each sample
+    pub fn n_features(&self) -> usize {
+        self.inner.distribution.n_features
     }
 }
 
@@ -346,6 +354,8 @@ mod tests {
         ]);
         let y = vec![2., 2., 0., 0., 0., 2., 1., 1., 0., 1., 0., 0., 2., 0., 2.];
         let nb = MultinomialNB::fit(&x, &y, Default::default()).unwrap();
+
+        assert_eq!(nb.n_features(), 10);
 
         let y_hat = nb.predict(&x).unwrap();
 

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -240,6 +240,12 @@ impl<T: RealNumber, M: Matrix<T>> MultinomialNB<T, M> {
     pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
         self.inner.predict(x)
     }
+
+    /// Class labels known to the classifier.
+    /// Returns a vector of size n_classes.
+    pub fn classes(&self) -> &Vec<T> {
+        &self.inner.distribution.class_labels
+    }
 }
 
 #[cfg(test)]
@@ -267,6 +273,8 @@ mod tests {
         ]);
         let y = vec![0., 0., 0., 1.];
         let mnb = MultinomialNB::fit(&x, &y, Default::default()).unwrap();
+
+        assert_eq!(mnb.classes(), &[0., 1.]);
 
         assert_eq!(mnb.inner.distribution.class_priors, &[0.75, 0.25]);
         assert_eq!(


### PR DESCRIPTION
This is related to https://github.com/smartcorelib/smartcore/issues/73:

Things that are done in this PR

- Add a getter equivalent to the scikitlearn attributes of the GaussianNB class for classes_, class_prior_, var_, and theta_.
- Rename sigma to var, in order to have a similar naming that in scikitlearn (sigma is [deprecated](https://github.com/scikit-learn/scikit-learn/blob/8c6a045e46abe94e43a971d4f8042728addfd6a7/sklearn/naive_bayes.py#L160))