### PR TITLE
fix: Change to compile for wasm32-unknown-unknown target

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn deserialize_data(
 ) -> Result<(Vec<f32>, Vec<f32>, usize, usize), io::Error> {
     // read the same file back into a Vec of bytes
     let (num_samples, num_features) = {
-        let mut buffer = [0u8; 8];
+        let mut buffer = [0u8; if cfg!(target_arch = "wasm32") { 4 } else { 8 }];
         buffer.copy_from_slice(&bytes[0..8]);
         let num_features = usize::from_le_bytes(buffer);
         buffer.copy_from_slice(&bytes[8..16]);


### PR DESCRIPTION
Right now if we run

```cargo build --target wasm32-unknown-unknown --release --all-features``` it fails with:

```bash
error[E0308]: mismatched types
  --> src/dataset/mod.rs:88:49
   |
88 |         let num_features = usize::from_le_bytes(buffer);
   |                                                 ^^^^^^ expected an array with a fixed size of 4 elements, found one with 8 elements

error[E0308]: mismatched types
  --> src/dataset/mod.rs:90:48
   |
90 |         let num_samples = usize::from_le_bytes(buffer);
   |                                                ^^^^^^ expected an array with a fixed size of 4 elements, found one with 8 elements

error: aborting due to 2 previous errors
```

According to the [documentation](https://doc.rust-lang.org/std/primitive.usize.html#method.from_le_bytes) from_le_bytes takes an array of length 2, 4 or 8 bytes depending on the target pointer size.


