### PR TITLE
feat: added support to wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           target: ${{ matrix.platform.target }}
           profile: minimal
           default: true
+      - name: Install test runner for wasm
+        if: matrix.platform.target == 'wasm32-unknown-unknown'
+        run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Stable Build
         uses: actions-rs/cargo@v1
         with:
@@ -49,3 +52,6 @@ jobs:
         with:
           command: test
           args: --all-features
+      - name: Tests in WASM
+        if: matrix.platform.target == 'wasm32-unknown-unknown'
+        run: wasm-pack test --node -- --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ rand = "0.7.3"
 rand_distr = "0.3.0"
 serde = { version = "1.0.115", features = ["derive"], optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+
 [dev-dependencies]
 criterion = "0.3"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ criterion = "0.3"
 serde_json = "1.0"
 bincode = "1.3.1"
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [[bench]]
 name = "distance"
 harness = false

--- a/src/algorithm/neighbour/bbd_tree.rs
+++ b/src/algorithm/neighbour/bbd_tree.rs
@@ -314,6 +314,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn bbdtree_iris() {
         let data = DenseMatrix::from_2d_array(&[

--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -467,6 +467,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cover_tree_test() {
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -483,7 +484,7 @@ mod tests {
         let knn: Vec<i32> = knn.iter().map(|v| *v.2).collect();
         assert_eq!(vec!(3, 4, 5, 6, 7), knn);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cover_tree_test1() {
         let data = vec![
@@ -502,7 +503,7 @@ mod tests {
 
         assert_eq!(vec!(0, 1, 2), knn);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/algorithm/neighbour/linear_search.rs
+++ b/src/algorithm/neighbour/linear_search.rs
@@ -150,6 +150,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_find() {
         let data1 = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -196,7 +197,7 @@ mod tests {
 
         assert_eq!(vec!(1, 2, 3), found_idxs2);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_point_eq() {
         let point1 = KNNPoint {

--- a/src/algorithm/sort/heap_select.rs
+++ b/src/algorithm/sort/heap_select.rs
@@ -96,12 +96,14 @@ impl<'a, T: PartialOrd + Debug> HeapSelection<T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn with_capacity() {
         let heap = HeapSelection::<i32>::with_capacity(3);
         assert_eq!(3, heap.k);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_add() {
         let mut heap = HeapSelection::with_capacity(3);
@@ -119,6 +121,7 @@ mod tests {
         assert_eq!(vec![2, 0, -5], heap.get());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_add1() {
         let mut heap = HeapSelection::with_capacity(3);
@@ -133,6 +136,7 @@ mod tests {
         assert_eq!(vec![0f64, -1f64, -5f64], heap.get());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_add2() {
         let mut heap = HeapSelection::with_capacity(3);
@@ -145,6 +149,7 @@ mod tests {
         assert_eq!(vec![5.6568, 2.8284, 0.0], heap.get());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_add_ordered() {
         let mut heap = HeapSelection::with_capacity(3);

--- a/src/algorithm/sort/quick_sort.rs
+++ b/src/algorithm/sort/quick_sort.rs
@@ -113,6 +113,7 @@ impl<T: Float> QuickArgSort for Vec<T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn with_capacity() {
         let arr1 = vec![0.3, 0.1, 0.2, 0.4, 0.9, 0.5, 0.7, 0.6, 0.8];

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -268,6 +268,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use crate::math::distance::euclidian::Euclidian;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_predict_dbscan() {
         let x = DenseMatrix::from_2d_array(&[
@@ -299,6 +300,7 @@ mod tests {
         assert_eq!(expected_labels, predicted_labels);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -299,6 +299,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn invalid_k() {
         let x = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);
@@ -312,6 +313,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_predict_iris() {
         let x = DenseMatrix::from_2d_array(&[
@@ -346,6 +348,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/dataset/boston.rs
+++ b/src/dataset/boston.rs
@@ -53,13 +53,14 @@ pub fn load_dataset() -> Dataset<f32, f32> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     use super::super::*;
     use super::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     #[ignore]
     fn refresh_boston_dataset() {

--- a/src/dataset/boston.rs
+++ b/src/dataset/boston.rs
@@ -69,7 +69,6 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn boston_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/boston.rs
+++ b/src/dataset/boston.rs
@@ -59,6 +59,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_boston_dataset() {
@@ -67,6 +68,8 @@ mod tests {
         assert!(serialize_data(&dataset, "boston.xy").is_ok());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn boston_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/boston.rs
+++ b/src/dataset/boston.rs
@@ -53,13 +53,13 @@ pub fn load_dataset() -> Dataset<f32, f32> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
 
     use super::super::*;
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_boston_dataset() {

--- a/src/dataset/breast_cancer.rs
+++ b/src/dataset/breast_cancer.rs
@@ -66,12 +66,13 @@ pub fn load_dataset() -> Dataset<f32, f32> {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     use super::super::*;
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
+    #[cfg(not(target_arch = "wasm32"))]
     fn refresh_cancer_dataset() {
         // run this test to generate breast_cancer.xy file.
         let dataset = load_dataset();

--- a/src/dataset/breast_cancer.rs
+++ b/src/dataset/breast_cancer.rs
@@ -69,6 +69,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_cancer_dataset() {
@@ -77,6 +78,7 @@ mod tests {
         assert!(serialize_data(&dataset, "breast_cancer.xy").is_ok());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cancer_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/diabetes.rs
+++ b/src/dataset/diabetes.rs
@@ -53,6 +53,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_diabetes_dataset() {
@@ -61,6 +62,7 @@ mod tests {
         assert!(serialize_data(&dataset, "diabetes.xy").is_ok());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn boston_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/diabetes.rs
+++ b/src/dataset/diabetes.rs
@@ -50,10 +50,11 @@ pub fn load_dataset() -> Dataset<f32, f32> {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     use super::super::*;
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     #[ignore]
     fn refresh_diabetes_dataset() {

--- a/src/dataset/digits.rs
+++ b/src/dataset/digits.rs
@@ -48,6 +48,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_digits_dataset() {
@@ -55,7 +56,7 @@ mod tests {
         let dataset = load_dataset();
         assert!(serialize_data(&dataset, "digits.xy").is_ok());
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn digits_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/digits.rs
+++ b/src/dataset/digits.rs
@@ -45,10 +45,11 @@ pub fn load_dataset() -> Dataset<f32, f32> {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     use super::super::*;
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     #[ignore]
     fn refresh_digits_dataset() {

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -137,6 +137,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_make_blobs() {
         let dataset = make_blobs(10, 2, 3);
@@ -149,6 +150,7 @@ mod tests {
         assert_eq!(dataset.num_samples, 10);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_make_circles() {
         let dataset = make_circles(10, 0.5, 0.05);
@@ -161,6 +163,7 @@ mod tests {
         assert_eq!(dataset.num_samples, 10);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_make_moons() {
         let dataset = make_moons(10, 0.05);

--- a/src/dataset/iris.rs
+++ b/src/dataset/iris.rs
@@ -53,6 +53,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[ignore]
     fn refresh_iris_dataset() {
@@ -61,6 +62,7 @@ mod tests {
         assert!(serialize_data(&dataset, "iris.xy").is_ok());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn iris_dataset() {
         let dataset = load_dataset();

--- a/src/dataset/iris.rs
+++ b/src/dataset/iris.rs
@@ -50,10 +50,11 @@ pub fn load_dataset() -> Dataset<f32, f32> {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(not(target_arch = "wasm32"))]
     use super::super::*;
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     #[ignore]
     fn refresh_iris_dataset() {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -116,6 +116,7 @@ pub(crate) fn deserialize_data(
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn as_matrix() {
         let dataset = Dataset {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -8,9 +8,12 @@ pub mod digits;
 pub mod generator;
 pub mod iris;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::math::num::RealNumber;
+#[cfg(not(target_arch = "wasm32"))]
 use std::fs::File;
 use std::io;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::prelude::*;
 
 /// Dataset
@@ -49,6 +52,8 @@ impl<X, Y> Dataset<X, Y> {
     }
 }
 
+// Running this in wasm throws: operation not supported on this platform.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 pub(crate) fn serialize_data<X: RealNumber, Y: RealNumber>(
     dataset: &Dataset<X, Y>,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -85,9 +85,9 @@ pub(crate) fn deserialize_data(
     const USIZE_SIZE: usize = std::mem::size_of::<usize>();
     let (num_samples, num_features) = {
         let mut buffer = [0u8; USIZE_SIZE];
-        buffer.copy_from_slice(&bytes[0..8]);
+        buffer.copy_from_slice(&bytes[0..USIZE_SIZE]);
         let num_features = usize::from_le_bytes(buffer);
-        buffer.copy_from_slice(&bytes[8..16]);
+        buffer.copy_from_slice(&bytes[8..8 + USIZE_SIZE]);
         let num_samples = usize::from_le_bytes(buffer);
         (num_samples, num_features)
     };

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -325,7 +325,7 @@ mod tests {
             &[6.8, 161.0, 60.0, 15.6],
         ])
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn pca_components() {
         let us_arrests = us_arrests_data();
@@ -341,7 +341,7 @@ mod tests {
 
         assert!(expected.approximate_eq(&pca.components().abs(), 0.4));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_covariance() {
         let us_arrests = us_arrests_data();
@@ -451,6 +451,7 @@ mod tests {
             .approximate_eq(&expected_projection.abs(), 1e-4));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_correlation() {
         let us_arrests = us_arrests_data();
@@ -566,6 +567,7 @@ mod tests {
             .approximate_eq(&expected_projection.abs(), 1e-4));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -153,6 +153,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn svd_decompose() {
         // https://stat.ethz.ch/R-manual/R-devel/library/datasets/html/USArrests.html
@@ -227,6 +228,7 @@ mod tests {
             .approximate_eq(&expected, 1e-4));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -279,6 +279,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::DenseMatrix;
     use crate::metrics::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_predict_iris() {
         let x = DenseMatrix::from_2d_array(&[
@@ -324,6 +325,7 @@ mod tests {
         assert!(accuracy(&y, &classifier.predict(&x).unwrap()) >= 0.95);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -231,6 +231,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::DenseMatrix;
     use crate::metrics::mean_absolute_error;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_longley() {
         let x = DenseMatrix::from_2d_array(&[
@@ -273,6 +274,7 @@ mod tests {
         assert!(mean_absolute_error(&y, &y_hat) < 1.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -168,7 +168,7 @@ pub trait CholeskyDecomposableMatrix<T: RealNumber>: BaseMatrix<T> {
 mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cholesky_decompose() {
         let a = DenseMatrix::from_2d_array(&[&[25., 15., -5.], &[15., 18., 0.], &[-5., 0., 11.]]);
@@ -187,6 +187,7 @@ mod tests {
             .approximate_eq(&a.abs(), 1e-4));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cholesky_solve_mut() {
         let a = DenseMatrix::from_2d_array(&[&[25., 15., -5.], &[15., 18., 0.], &[-5., 0., 11.]]);

--- a/src/linalg/evd.rs
+++ b/src/linalg/evd.rs
@@ -816,7 +816,7 @@ fn sort<T: RealNumber, M: BaseMatrix<T>>(d: &mut Vec<T>, e: &mut Vec<T>, V: &mut
 mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_symmetric() {
         let A = DenseMatrix::from_2d_array(&[
@@ -843,7 +843,7 @@ mod tests {
             assert!((0f64 - evd.e[i]).abs() < std::f64::EPSILON);
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_asymmetric() {
         let A = DenseMatrix::from_2d_array(&[
@@ -870,7 +870,7 @@ mod tests {
             assert!((0f64 - evd.e[i]).abs() < std::f64::EPSILON);
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_complex() {
         let A = DenseMatrix::from_2d_array(&[

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -260,6 +260,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[0., 1., 5.], &[5., 6., 0.]]);
@@ -274,7 +275,7 @@ mod tests {
         assert!(lu.U().approximate_eq(&expected_U, 1e-4));
         assert!(lu.pivot().approximate_eq(&expected_pivot, 1e-4));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn inverse() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[0., 1., 5.], &[5., 6., 0.]]);

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -706,6 +706,7 @@ mod tests {
     use crate::linalg::BaseMatrix;
     use crate::linalg::BaseVector;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mean() {
         let m = vec![1., 2., 3.];
@@ -713,6 +714,7 @@ mod tests {
         assert_eq!(m.mean(), 2.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn std() {
         let m = vec![1., 2., 3.];
@@ -720,6 +722,7 @@ mod tests {
         assert!((m.std() - 0.81f64).abs() < 1e-2);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn var() {
         let m = vec![1., 2., 3., 4.];
@@ -727,6 +730,7 @@ mod tests {
         assert!((m.var() - 1.25f64).abs() < std::f64::EPSILON);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_take() {
         let m = vec![1., 2., 3., 4., 5.];
@@ -734,6 +738,7 @@ mod tests {
         assert_eq!(m.take(&vec!(0, 0, 4, 4)), vec![1., 1., 5., 5.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn take() {
         let m = DenseMatrix::from_2d_array(&[

--- a/src/linalg/naive/dense_matrix.rs
+++ b/src/linalg/naive/dense_matrix.rs
@@ -1060,14 +1060,14 @@ impl<T: RealNumber> BaseMatrix<T> for DenseMatrix<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_dot() {
         let v1 = vec![1., 2., 3.];
         let v2 = vec![4., 5., 6.];
         assert_eq!(32.0, BaseVector::dot(&v1, &v2));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_copy_from() {
         let mut v1 = vec![1., 2., 3.];
@@ -1075,7 +1075,7 @@ mod tests {
         v1.copy_from(&v2);
         assert_eq!(v1, v2);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_approximate_eq() {
         let a = vec![1., 2., 3.];
@@ -1083,7 +1083,7 @@ mod tests {
         assert!(a.approximate_eq(&b, 1e-4));
         assert!(!a.approximate_eq(&b, 1e-5));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn from_array() {
         let vec = [1., 2., 3., 4., 5., 6.];
@@ -1096,7 +1096,7 @@ mod tests {
             DenseMatrix::new(2, 3, vec![1., 4., 2., 5., 3., 6.])
         );
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn row_column_vec_from_array() {
         let vec = vec![1., 2., 3., 4., 5., 6.];
@@ -1109,7 +1109,7 @@ mod tests {
             DenseMatrix::new(6, 1, vec![1., 2., 3., 4., 5., 6.])
         );
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn from_to_row_vec() {
         let vec = vec![1., 2., 3.];
@@ -1122,20 +1122,20 @@ mod tests {
             vec![1., 2., 3.]
         );
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_matrix_to_row_vector() {
         let m: DenseMatrix<f64> = BaseMatrix::zeros(10, 1);
         assert_eq!(m.to_row_vector().len(), 10)
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn iter() {
         let vec = vec![1., 2., 3., 4., 5., 6.];
         let m = DenseMatrix::from_array(3, 2, &vec);
         assert_eq!(vec, m.iter().collect::<Vec<f32>>());
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn v_stack() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);
@@ -1150,7 +1150,7 @@ mod tests {
         let result = a.v_stack(&b);
         assert_eq!(result, expected);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn h_stack() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);
@@ -1163,13 +1163,13 @@ mod tests {
         let result = a.h_stack(&b);
         assert_eq!(result, expected);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_row() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);
         assert_eq!(vec![4., 5., 6.], a.get_row(1));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn matmul() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);
@@ -1178,7 +1178,7 @@ mod tests {
         let result = a.matmul(&b);
         assert_eq!(result, expected);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ab() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);
@@ -1201,14 +1201,14 @@ mod tests {
             DenseMatrix::from_2d_array(&[&[29., 39., 49.], &[40., 54., 68.,], &[51., 69., 87.]])
         );
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn dot() {
         let a = DenseMatrix::from_array(1, 3, &[1., 2., 3.]);
         let b = DenseMatrix::from_array(1, 3, &[4., 5., 6.]);
         assert_eq!(a.dot(&b), 32.);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn copy_from() {
         let mut a = DenseMatrix::from_2d_array(&[&[1., 2.], &[3., 4.], &[5., 6.]]);
@@ -1216,7 +1216,7 @@ mod tests {
         a.copy_from(&b);
         assert_eq!(a, b);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn slice() {
         let m = DenseMatrix::from_2d_array(&[
@@ -1228,7 +1228,7 @@ mod tests {
         let result = m.slice(0..2, 1..3);
         assert_eq!(result, expected);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn approximate_eq() {
         let m = DenseMatrix::from_2d_array(&[&[2., 3.], &[5., 6.]]);
@@ -1237,7 +1237,7 @@ mod tests {
         assert!(m.approximate_eq(&m_eq, 0.5));
         assert!(!m.approximate_eq(&m_neq, 0.5));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn rand() {
         let m: DenseMatrix<f64> = DenseMatrix::rand(3, 3);
@@ -1247,7 +1247,7 @@ mod tests {
             }
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn transpose() {
         let m = DenseMatrix::from_2d_array(&[&[1.0, 3.0], &[2.0, 4.0]]);
@@ -1259,7 +1259,7 @@ mod tests {
             }
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn reshape() {
         let m_orig = DenseMatrix::row_vector_from_array(&[1., 2., 3., 4., 5., 6.]);
@@ -1270,7 +1270,7 @@ mod tests {
         assert_eq!(m_result.get(0, 1), 2.);
         assert_eq!(m_result.get(0, 3), 4.);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn norm() {
         let v = DenseMatrix::row_vector_from_array(&[3., -2., 6.]);
@@ -1279,7 +1279,7 @@ mod tests {
         assert_eq!(v.norm(std::f64::INFINITY), 6.);
         assert_eq!(v.norm(std::f64::NEG_INFINITY), 2.);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn softmax_mut() {
         let mut prob: DenseMatrix<f64> = DenseMatrix::row_vector_from_array(&[1., 2., 3.]);
@@ -1288,14 +1288,14 @@ mod tests {
         assert!((prob.get(0, 1) - 0.24).abs() < 0.01);
         assert!((prob.get(0, 2) - 0.66).abs() < 0.01);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_mean() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);
         let res = a.column_mean();
         assert_eq!(res, vec![4., 5., 6.]);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn min_max_sum() {
         let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);
@@ -1303,14 +1303,14 @@ mod tests {
         assert_eq!(1., a.min());
         assert_eq!(6., a.max());
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn eye() {
         let a = DenseMatrix::from_2d_array(&[&[1., 0., 0.], &[0., 1., 0.], &[0., 0., 1.]]);
         let res = DenseMatrix::eye(3);
         assert_eq!(res, a);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn to_from_json() {
@@ -1319,7 +1319,7 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&a).unwrap()).unwrap();
         assert_eq!(a, deserialized_a);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn to_from_bincode() {
@@ -1328,7 +1328,7 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&a).unwrap()).unwrap();
         assert_eq!(a, deserialized_a);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn to_string() {
         let a = DenseMatrix::from_2d_array(&[&[0.9, 0.4, 0.7], &[0.4, 0.5, 0.3], &[0.7, 0.3, 0.8]]);
@@ -1337,7 +1337,7 @@ mod tests {
             "[[0.9, 0.4, 0.7], [0.4, 0.5, 0.3], [0.7, 0.3, 0.8]]"
         );
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn cov() {
         let a = DenseMatrix::from_2d_array(&[

--- a/src/linalg/nalgebra_bindings.rs
+++ b/src/linalg/nalgebra_bindings.rs
@@ -579,6 +579,7 @@ mod tests {
     use crate::linear::linear_regression::*;
     use nalgebra::{DMatrix, Matrix2x3, RowDVector};
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_copy_from() {
         let mut v1 = RowDVector::from_vec(vec![1., 2., 3.]);
@@ -589,12 +590,14 @@ mod tests {
         assert_ne!(v2, v1);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_len() {
         let v = RowDVector::from_vec(vec![1., 2., 3.]);
         assert_eq!(3, v.len());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_set_vector() {
         let mut v = RowDVector::from_vec(vec![1., 2., 3., 4.]);
@@ -607,12 +610,14 @@ mod tests {
         assert_eq!(5., BaseVector::get(&v, 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_to_vec() {
         let v = RowDVector::from_vec(vec![1., 2., 3.]);
         assert_eq!(vec![1., 2., 3.], v.to_vec());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_init() {
         let zeros: RowDVector<f32> = BaseVector::zeros(3);
@@ -623,6 +628,7 @@ mod tests {
         assert_eq!(twos, RowDVector::from_vec(vec![2., 2., 2.]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_dot() {
         let v1 = RowDVector::from_vec(vec![1., 2., 3.]);
@@ -630,6 +636,7 @@ mod tests {
         assert_eq!(32.0, BaseVector::dot(&v1, &v2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_approximate_eq() {
         let a = RowDVector::from_vec(vec![1., 2., 3.]);
@@ -638,6 +645,7 @@ mod tests {
         assert!(!a.approximate_eq(&(&noise + &a), 1e-5));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_set_dynamic() {
         let mut m = DMatrix::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -650,6 +658,7 @@ mod tests {
         assert_eq!(10., BaseMatrix::get(&m, 1, 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn zeros() {
         let expected = DMatrix::from_row_slice(2, 2, &[0., 0., 0., 0.]);
@@ -659,6 +668,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ones() {
         let expected = DMatrix::from_row_slice(2, 2, &[1., 1., 1., 1.]);
@@ -668,6 +678,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn eye() {
         let expected = DMatrix::from_row_slice(3, 3, &[1., 0., 0., 0., 1., 0., 0., 0., 1.]);
@@ -675,6 +686,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn shape() {
         let m: DMatrix<f64> = BaseMatrix::zeros(5, 10);
@@ -684,6 +696,7 @@ mod tests {
         assert_eq!(ncols, 10);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn scalar_add_sub_mul_div() {
         let mut m = DMatrix::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -697,6 +710,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn add_sub_mul_div() {
         let mut m = DMatrix::from_row_slice(2, 2, &[1.0, 2.0, 3.0, 4.0]);
@@ -715,6 +729,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn to_from_row_vector() {
         let v = RowDVector::from_vec(vec![1., 2., 3., 4.]);
@@ -723,12 +738,14 @@ mod tests {
         assert_eq!(m.to_row_vector(), expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_matrix_to_row_vector() {
         let m: DMatrix<f64> = BaseMatrix::zeros(10, 1);
         assert_eq!(m.to_row_vector().len(), 10)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_row_col_as_vec() {
         let m = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
@@ -737,12 +754,14 @@ mod tests {
         assert_eq!(m.get_col_as_vec(1), vec!(2., 5., 8.));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_row() {
         let a = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
         assert_eq!(RowDVector::from_vec(vec![4., 5., 6.]), a.get_row(1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn copy_row_col_as_vec() {
         let m = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
@@ -754,6 +773,7 @@ mod tests {
         assert_eq!(v, vec!(2., 5., 8.));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn element_add_sub_mul_div() {
         let mut m = DMatrix::from_row_slice(2, 2, &[1.0, 2.0, 3.0, 4.0]);
@@ -767,6 +787,7 @@ mod tests {
         assert_eq!(m, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vstack_hstack() {
         let m1 = DMatrix::from_row_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
@@ -782,6 +803,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn matmul() {
         let a = DMatrix::from_row_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
@@ -791,6 +813,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn dot() {
         let a = DMatrix::from_row_slice(1, 3, &[1., 2., 3.]);
@@ -798,6 +821,7 @@ mod tests {
         assert_eq!(14., a.dot(&b));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn slice() {
         let a = DMatrix::from_row_slice(
@@ -810,6 +834,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn approximate_eq() {
         let a = DMatrix::from_row_slice(3, 3, &[1., 2., 3., 4., 5., 6., 7., 8., 9.]);
@@ -822,6 +847,7 @@ mod tests {
         assert!(!a.approximate_eq(&(&noise + &a), 1e-5));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn negative_mut() {
         let mut v = DMatrix::from_row_slice(1, 3, &[3., -2., 6.]);
@@ -829,6 +855,7 @@ mod tests {
         assert_eq!(v, DMatrix::from_row_slice(1, 3, &[-3., 2., -6.]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn transpose() {
         let m = DMatrix::from_row_slice(2, 2, &[1.0, 3.0, 2.0, 4.0]);
@@ -837,6 +864,7 @@ mod tests {
         assert_eq!(m_transposed, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn rand() {
         let m: DMatrix<f64> = BaseMatrix::rand(3, 3);
@@ -847,6 +875,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn norm() {
         let v = DMatrix::from_row_slice(1, 3, &[3., -2., 6.]);
@@ -856,6 +885,7 @@ mod tests {
         assert_eq!(BaseMatrix::norm(&v, std::f64::NEG_INFINITY), 2.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_mean() {
         let a = DMatrix::from_row_slice(3, 3, &[1., 2., 3., 4., 5., 6., 7., 8., 9.]);
@@ -863,6 +893,7 @@ mod tests {
         assert_eq!(res, vec![4., 5., 6.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn reshape() {
         let m_orig = DMatrix::from_row_slice(1, 6, &[1., 2., 3., 4., 5., 6.]);
@@ -874,6 +905,7 @@ mod tests {
         assert_eq!(BaseMatrix::get(&m_result, 0, 3), 4.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn copy_from() {
         let mut src = DMatrix::from_row_slice(1, 3, &[1., 2., 3.]);
@@ -882,6 +914,7 @@ mod tests {
         assert_eq!(src, dst);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn abs_mut() {
         let mut a = DMatrix::from_row_slice(2, 2, &[1., -2., 3., -4.]);
@@ -890,6 +923,7 @@ mod tests {
         assert_eq!(a, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn min_max_sum() {
         let a = DMatrix::from_row_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
@@ -898,6 +932,7 @@ mod tests {
         assert_eq!(6., a.max());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn max_diff() {
         let a1 = DMatrix::from_row_slice(2, 3, &[1., 2., 3., 4., -5., 6.]);
@@ -906,6 +941,7 @@ mod tests {
         assert_eq!(a2.max_diff(&a2), 0.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn softmax_mut() {
         let mut prob: DMatrix<f64> = DMatrix::from_row_slice(1, 3, &[1., 2., 3.]);
@@ -915,6 +951,7 @@ mod tests {
         assert!((BaseMatrix::get(&prob, 0, 2) - 0.66).abs() < 0.01);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn pow_mut() {
         let mut a = DMatrix::from_row_slice(1, 3, &[1., 2., 3.]);
@@ -922,6 +959,7 @@ mod tests {
         assert_eq!(a, DMatrix::from_row_slice(1, 3, &[1., 8., 27.]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn argmax() {
         let a = DMatrix::from_row_slice(3, 3, &[1., 2., 3., -5., -6., -7., 0.1, 0.2, 0.1]);
@@ -929,6 +967,7 @@ mod tests {
         assert_eq!(res, vec![2, 0, 1]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn unique() {
         let a = DMatrix::from_row_slice(3, 3, &[1., 2., 2., -2., -6., -7., 2., 3., 4.]);
@@ -937,6 +976,7 @@ mod tests {
         assert_eq!(res, vec![-7., -6., -2., 1., 2., 3., 4.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ols_fit_predict() {
         let x = DMatrix::from_row_slice(

--- a/src/linalg/ndarray_bindings.rs
+++ b/src/linalg/ndarray_bindings.rs
@@ -530,6 +530,7 @@ mod tests {
     use crate::metrics::mean_absolute_error;
     use ndarray::{arr1, arr2, Array1, Array2};
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_get_set() {
         let mut result = arr1(&[1., 2., 3.]);
@@ -541,6 +542,7 @@ mod tests {
         assert_eq!(5., BaseVector::get(&result, 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_copy_from() {
         let mut v1 = arr1(&[1., 2., 3.]);
@@ -551,18 +553,21 @@ mod tests {
         assert_ne!(v1, v2);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_len() {
         let v = arr1(&[1., 2., 3.]);
         assert_eq!(3, v.len());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_to_vec() {
         let v = arr1(&[1., 2., 3.]);
         assert_eq!(vec![1., 2., 3.], v.to_vec());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_dot() {
         let v1 = arr1(&[1., 2., 3.]);
@@ -570,6 +575,7 @@ mod tests {
         assert_eq!(32.0, BaseVector::dot(&v1, &v2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vec_approximate_eq() {
         let a = arr1(&[1., 2., 3.]);
@@ -578,6 +584,7 @@ mod tests {
         assert!(!a.approximate_eq(&(&noise + &a), 1e-5));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn from_to_row_vec() {
         let vec = arr1(&[1., 2., 3.]);
@@ -588,12 +595,14 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_matrix_to_row_vector() {
         let m: Array2<f64> = BaseMatrix::zeros(10, 1);
         assert_eq!(m.to_row_vector().len(), 10)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn add_mut() {
         let mut a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -604,6 +613,7 @@ mod tests {
         assert_eq!(a1, a3);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn sub_mut() {
         let mut a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -614,6 +624,7 @@ mod tests {
         assert_eq!(a1, a3);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mul_mut() {
         let mut a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -624,6 +635,7 @@ mod tests {
         assert_eq!(a1, a3);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn div_mut() {
         let mut a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -634,6 +646,7 @@ mod tests {
         assert_eq!(a1, a3);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn div_element_mut() {
         let mut a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -642,6 +655,7 @@ mod tests {
         assert_eq!(BaseMatrix::get(&a, 1, 1), 1.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mul_element_mut() {
         let mut a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -650,6 +664,7 @@ mod tests {
         assert_eq!(BaseMatrix::get(&a, 1, 1), 25.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn add_element_mut() {
         let mut a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -657,7 +672,7 @@ mod tests {
 
         assert_eq!(BaseMatrix::get(&a, 1, 1), 10.);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn sub_element_mut() {
         let mut a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -666,6 +681,7 @@ mod tests {
         assert_eq!(BaseMatrix::get(&a, 1, 1), 0.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn vstack_hstack() {
         let a1 = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -680,6 +696,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_set() {
         let mut result = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -691,6 +708,7 @@ mod tests {
         assert_eq!(10., BaseMatrix::get(&result, 1, 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn matmul() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -700,6 +718,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn dot() {
         let a = arr2(&[[1., 2., 3.]]);
@@ -707,6 +726,7 @@ mod tests {
         assert_eq!(14., BaseMatrix::dot(&a, &b));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn slice() {
         let a = arr2(&[
@@ -719,6 +739,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn scalar_ops() {
         let a = arr2(&[[1., 2., 3.]]);
@@ -728,6 +749,7 @@ mod tests {
         assert_eq!(&arr2(&[[0.5, 1., 1.5]]), a.clone().div_scalar_mut(2.));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn transpose() {
         let m = arr2(&[[1.0, 3.0], [2.0, 4.0]]);
@@ -736,6 +758,7 @@ mod tests {
         assert_eq!(m_transposed, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn norm() {
         let v = arr2(&[[3., -2., 6.]]);
@@ -745,6 +768,7 @@ mod tests {
         assert_eq!(v.norm(std::f64::NEG_INFINITY), 2.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn negative_mut() {
         let mut v = arr2(&[[3., -2., 6.]]);
@@ -752,6 +776,7 @@ mod tests {
         assert_eq!(v, arr2(&[[-3., 2., -6.]]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn reshape() {
         let m_orig = arr2(&[[1., 2., 3., 4., 5., 6.]]);
@@ -763,6 +788,7 @@ mod tests {
         assert_eq!(BaseMatrix::get(&m_result, 0, 3), 4.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn copy_from() {
         let mut src = arr2(&[[1., 2., 3.]]);
@@ -771,6 +797,7 @@ mod tests {
         assert_eq!(src, dst);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn min_max_sum() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.]]);
@@ -779,6 +806,7 @@ mod tests {
         assert_eq!(6., a.max());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn max_diff() {
         let a1 = arr2(&[[1., 2., 3.], [4., -5., 6.]]);
@@ -787,6 +815,7 @@ mod tests {
         assert_eq!(a2.max_diff(&a2), 0.);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn softmax_mut() {
         let mut prob: Array2<f64> = arr2(&[[1., 2., 3.]]);
@@ -796,6 +825,7 @@ mod tests {
         assert!((BaseMatrix::get(&prob, 0, 2) - 0.66).abs() < 0.01);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn pow_mut() {
         let mut a = arr2(&[[1., 2., 3.]]);
@@ -803,6 +833,7 @@ mod tests {
         assert_eq!(a, arr2(&[[1., 8., 27.]]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn argmax() {
         let a = arr2(&[[1., 2., 3.], [-5., -6., -7.], [0.1, 0.2, 0.1]]);
@@ -810,6 +841,7 @@ mod tests {
         assert_eq!(res, vec![2, 0, 1]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn unique() {
         let a = arr2(&[[1., 2., 2.], [-2., -6., -7.], [2., 3., 4.]]);
@@ -818,6 +850,7 @@ mod tests {
         assert_eq!(res, vec![-7., -6., -2., 1., 2., 3., 4.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_row_as_vector() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
@@ -825,12 +858,14 @@ mod tests {
         assert_eq!(res, vec![4., 5., 6.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_row() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         assert_eq!(arr1(&[4., 5., 6.]), a.get_row(1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn get_col_as_vector() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
@@ -838,6 +873,7 @@ mod tests {
         assert_eq!(res, vec![2., 5., 8.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn copy_row_col_as_vec() {
         let m = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
@@ -849,6 +885,7 @@ mod tests {
         assert_eq!(v, vec!(2., 5., 8.));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn col_mean() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
@@ -856,6 +893,7 @@ mod tests {
         assert_eq!(res, vec![4., 5., 6.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn eye() {
         let a = arr2(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
@@ -863,6 +901,7 @@ mod tests {
         assert_eq!(res, a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn rand() {
         let m: Array2<f64> = BaseMatrix::rand(3, 3);
@@ -873,6 +912,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn approximate_eq() {
         let a = arr2(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
@@ -881,6 +921,7 @@ mod tests {
         assert!(!a.approximate_eq(&(&noise + &a), 1e-5));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn abs_mut() {
         let mut a = arr2(&[[1., -2.], [3., -4.]]);
@@ -889,6 +930,7 @@ mod tests {
         assert_eq!(a, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lr_fit_predict_iris() {
         let x = arr2(&[
@@ -930,6 +972,7 @@ mod tests {
         assert!(error <= 1.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn my_fit_longley_ndarray() {
         let x = arr2(&[

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -195,7 +195,7 @@ pub trait QRDecomposableMatrix<T: RealNumber>: BaseMatrix<T> {
 mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose() {
         let a = DenseMatrix::from_2d_array(&[&[0.9, 0.4, 0.7], &[0.4, 0.5, 0.3], &[0.7, 0.3, 0.8]]);
@@ -214,6 +214,7 @@ mod tests {
         assert!(qr.R().abs().approximate_eq(&r.abs(), 1e-4));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn qr_solve_mut() {
         let a = DenseMatrix::from_2d_array(&[&[0.9, 0.4, 0.7], &[0.4, 0.5, 0.3], &[0.7, 0.3, 0.8]]);

--- a/src/linalg/stats.rs
+++ b/src/linalg/stats.rs
@@ -150,7 +150,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
     use crate::linalg::BaseVector;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mean() {
         let m = DenseMatrix::from_2d_array(&[
@@ -164,7 +164,7 @@ mod tests {
         assert_eq!(m.mean(0), expected_0);
         assert_eq!(m.mean(1), expected_1);
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn std() {
         let m = DenseMatrix::from_2d_array(&[
@@ -178,7 +178,7 @@ mod tests {
         assert!(m.std(0).approximate_eq(&expected_0, 1e-2));
         assert!(m.std(1).approximate_eq(&expected_1, 1e-2));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn var() {
         let m = DenseMatrix::from_2d_array(&[&[1., 2., 3., 4.], &[5., 6., 7., 8.]]);
@@ -188,7 +188,7 @@ mod tests {
         assert!(m.var(0).approximate_eq(&expected_0, std::f64::EPSILON));
         assert!(m.var(1).approximate_eq(&expected_1, std::f64::EPSILON));
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn scale() {
         let mut m = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -482,7 +482,7 @@ impl<T: RealNumber, M: SVDDecomposableMatrix<T>> SVD<T, M> {
 mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_symmetric() {
         let A = DenseMatrix::from_2d_array(&[
@@ -513,7 +513,7 @@ mod tests {
             assert!((s[i] - svd.s[i]).abs() < 1e-4);
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_asymmetric() {
         let A = DenseMatrix::from_2d_array(&[
@@ -714,7 +714,7 @@ mod tests {
             assert!((s[i] - svd.s[i]).abs() < 1e-4);
         }
     }
-
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn solve() {
         let a = DenseMatrix::from_2d_array(&[&[0.9, 0.4, 0.7], &[0.4, 0.5, 0.3], &[0.7, 0.3, 0.8]]);
@@ -725,6 +725,7 @@ mod tests {
         assert!(w.approximate_eq(&expected_w, 1e-2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn decompose_restore() {
         let a = DenseMatrix::from_2d_array(&[&[1.0, 2.0, 3.0, 4.0], &[5.0, 6.0, 7.0, 8.0]]);

--- a/src/linear/bg_solver.rs
+++ b/src/linear/bg_solver.rs
@@ -126,6 +126,7 @@ mod tests {
 
     impl<T: RealNumber, M: Matrix<T>> BiconjugateGradientSolver<T, M> for BGSolver {}
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn bg_solver() {
         let a = DenseMatrix::from_2d_array(&[&[25., 15., -5.], &[15., 18., 0.], &[-5., 0., 11.]]);

--- a/src/linear/elastic_net.rs
+++ b/src/linear/elastic_net.rs
@@ -291,6 +291,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::*;
     use crate::metrics::mean_absolute_error;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn elasticnet_longley() {
         let x = DenseMatrix::from_2d_array(&[
@@ -334,6 +335,7 @@ mod tests {
         assert!(mean_absolute_error(&y_hat, &y) < 30.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn elasticnet_fit_predict1() {
         let x = DenseMatrix::from_2d_array(&[
@@ -400,6 +402,7 @@ mod tests {
         assert!(l1_model.coefficients().get(0, 0) > l1_model.coefficients().get(2, 0));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/linear/lasso.rs
+++ b/src/linear/lasso.rs
@@ -226,6 +226,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::*;
     use crate::metrics::mean_absolute_error;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lasso_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -274,6 +275,7 @@ mod tests {
         assert!(mean_absolute_error(&y_hat, &y) < 2.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -200,6 +200,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ols_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -250,6 +251,7 @@ mod tests {
             .all(|(&a, &b)| (a - b).abs() <= 5.0));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -452,6 +452,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::*;
     use crate::metrics::accuracy;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn multiclass_objective_f() {
         let x = DenseMatrix::from_2d_array(&[
@@ -519,6 +520,7 @@ mod tests {
         assert!((g.get(0, 0).abs() - 32.0).abs() < 1e-4);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn binary_objective_f() {
         let x = DenseMatrix::from_2d_array(&[
@@ -575,6 +577,7 @@ mod tests {
         assert!((g.get(0, 2) - 3.8693).abs() < 1e-4);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lr_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -612,6 +615,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lr_fit_predict_multiclass() {
         let blobs = make_blobs(15, 4, 3);
@@ -635,6 +639,7 @@ mod tests {
         assert!(lr_reg.coefficients().abs().sum() < lr.coefficients().abs().sum());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lr_fit_predict_binary() {
         let blobs = make_blobs(20, 4, 2);
@@ -658,6 +663,7 @@ mod tests {
         assert!(lr_reg.coefficients().abs().sum() < lr.coefficients().abs().sum());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {
@@ -688,6 +694,7 @@ mod tests {
         assert_eq!(lr, deserialized_lr);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lr_fit_predict_iris() {
         let x = DenseMatrix::from_2d_array(&[

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -274,6 +274,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::*;
     use crate::metrics::mean_absolute_error;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ridge_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -329,6 +330,7 @@ mod tests {
         assert!(mean_absolute_error(&y_hat_svd, &y) < 2.0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/math/distance/euclidian.rs
+++ b/src/math/distance/euclidian.rs
@@ -57,6 +57,7 @@ impl<T: RealNumber> Distance<Vec<T>, T> for Euclidian {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn squared_distance() {
         let a = vec![1., 2., 3.];

--- a/src/math/distance/hamming.rs
+++ b/src/math/distance/hamming.rs
@@ -52,6 +52,7 @@ impl<T: PartialEq, F: RealNumber> Distance<Vec<T>, F> for Hamming {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn hamming_distance() {
         let a = vec![1, 0, 0, 1, 0, 0, 1];

--- a/src/math/distance/mahalanobis.rs
+++ b/src/math/distance/mahalanobis.rs
@@ -133,6 +133,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mahalanobis_distance() {
         let data = DenseMatrix::from_2d_array(&[

--- a/src/math/distance/manhattan.rs
+++ b/src/math/distance/manhattan.rs
@@ -48,6 +48,7 @@ impl<T: RealNumber> Distance<Vec<T>, T> for Manhattan {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn manhattan_distance() {
         let a = vec![1., 2., 3.];

--- a/src/math/distance/minkowski.rs
+++ b/src/math/distance/minkowski.rs
@@ -76,7 +76,6 @@ mod tests {
         assert!((l3 - 4.32674871).abs() < 1e-8);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "p must be at least 1")]
     fn minkowski_distance_negative_p() {

--- a/src/math/distance/minkowski.rs
+++ b/src/math/distance/minkowski.rs
@@ -61,6 +61,7 @@ impl<T: RealNumber> Distance<Vec<T>, T> for Minkowski {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn minkowski_distance() {
         let a = vec![1., 2., 3.];
@@ -75,6 +76,7 @@ mod tests {
         assert!((l3 - 4.32674871).abs() < 1e-8);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "p must be at least 1")]
     fn minkowski_distance_negative_p() {

--- a/src/math/num.rs
+++ b/src/math/num.rs
@@ -136,6 +136,7 @@ impl RealNumber for f32 {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn sigmoid() {
         assert_eq!(1.0.sigmoid(), 0.7310585786300049);

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -30,6 +30,7 @@ impl<T: RealNumber, V: BaseVector<T>> RealNumberVector<T> for V {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn unique_with_indices() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];

--- a/src/metrics/accuracy.rs
+++ b/src/metrics/accuracy.rs
@@ -57,6 +57,7 @@ impl Accuracy {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn accuracy() {
         let y_pred: Vec<f64> = vec![0., 2., 1., 3.];

--- a/src/metrics/auc.rs
+++ b/src/metrics/auc.rs
@@ -93,6 +93,7 @@ impl AUC {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn auc() {
         let y_true: Vec<f64> = vec![0., 0., 1., 1.];

--- a/src/metrics/cluster_hcv.rs
+++ b/src/metrics/cluster_hcv.rs
@@ -43,6 +43,7 @@ impl HCVScore {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn homogeneity_score() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];

--- a/src/metrics/cluster_helpers.rs
+++ b/src/metrics/cluster_helpers.rs
@@ -101,6 +101,7 @@ pub fn mutual_info_score<T: RealNumber>(contingency: &[Vec<usize>]) -> T {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn contingency_matrix_test() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];
@@ -112,6 +113,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn entropy_test() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];
@@ -119,6 +121,7 @@ mod tests {
         assert!((1.2770f32 - entropy(&v1).unwrap()).abs() < 1e-4);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mutual_info_score_test() {
         let v1 = vec![0.0, 0.0, 1.0, 1.0, 2.0, 0.0, 4.0];

--- a/src/metrics/f1.rs
+++ b/src/metrics/f1.rs
@@ -59,6 +59,7 @@ impl<T: RealNumber> F1<T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn f1() {
         let y_pred: Vec<f64> = vec![0., 0., 1., 1., 1., 1.];

--- a/src/metrics/mean_absolute_error.rs
+++ b/src/metrics/mean_absolute_error.rs
@@ -56,6 +56,7 @@ impl MeanAbsoluteError {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mean_absolute_error() {
         let y_true: Vec<f64> = vec![3., -0.5, 2., 7.];

--- a/src/metrics/mean_squared_error.rs
+++ b/src/metrics/mean_squared_error.rs
@@ -56,6 +56,7 @@ impl MeanSquareError {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn mean_squared_error() {
         let y_true: Vec<f64> = vec![3., -0.5, 2., 7.];

--- a/src/metrics/precision.rs
+++ b/src/metrics/precision.rs
@@ -77,6 +77,7 @@ impl Precision {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn precision() {
         let y_true: Vec<f64> = vec![0., 1., 1., 0.];

--- a/src/metrics/r2.rs
+++ b/src/metrics/r2.rs
@@ -70,6 +70,7 @@ impl R2 {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn r2() {
         let y_true: Vec<f64> = vec![3., -0.5, 2., 7.];

--- a/src/metrics/recall.rs
+++ b/src/metrics/recall.rs
@@ -77,6 +77,7 @@ impl Recall {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn recall() {
         let y_true: Vec<f64> = vec![0., 1., 1., 0.];

--- a/src/model_selection/kfold.rs
+++ b/src/model_selection/kfold.rs
@@ -144,6 +144,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_kfold_return_test_indices_simple() {
         let k = KFold {
@@ -158,6 +159,7 @@ mod tests {
         assert_eq!(test_indices[2], (22..33).collect::<Vec<usize>>());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_kfold_return_test_indices_odd() {
         let k = KFold {
@@ -172,6 +174,7 @@ mod tests {
         assert_eq!(test_indices[2], (23..34).collect::<Vec<usize>>());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_kfold_return_test_mask_simple() {
         let k = KFold {
@@ -197,6 +200,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_kfold_return_split_simple() {
         let k = KFold {
@@ -212,6 +216,7 @@ mod tests {
         assert_eq!(train_test_splits[1].1, (11..22).collect::<Vec<usize>>());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_kfold_return_split_simple_shuffle() {
         let k = KFold {
@@ -227,6 +232,7 @@ mod tests {
         assert_eq!(train_test_splits[1].1.len(), 11_usize);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn numpy_parity_test() {
         let k = KFold {
@@ -247,6 +253,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn numpy_parity_test_shuffle() {
         let k = KFold {

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -285,6 +285,7 @@ mod tests {
     use crate::model_selection::kfold::KFold;
     use crate::neighbors::knn_regressor::KNNRegressor;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_train_test_split() {
         let n = 123;
@@ -308,6 +309,7 @@ mod tests {
     #[derive(Clone)]
     struct NoParameters {}
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_cross_validate_biased() {
         struct BiasedEstimator {}
@@ -367,6 +369,7 @@ mod tests {
         assert_eq!(0.4, results.mean_train_score());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_cross_validate_knn() {
         let x = DenseMatrix::from_2d_array(&[
@@ -411,6 +414,7 @@ mod tests {
         assert!(results.mean_train_score() < results.mean_test_score());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_cross_val_predict_knn() {
         let x = DenseMatrix::from_2d_array(&[

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -346,6 +346,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_bernoulli_naive_bayes() {
         // Tests that BernoulliNB when alpha=1.0 gives the same values as
@@ -398,6 +399,7 @@ mod tests {
         assert_eq!(y_hat, &[1.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn bernoulli_nb_scikit_parity() {
         let x = DenseMatrix::<f64>::from_2d_array(&[
@@ -460,6 +462,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -351,6 +351,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_categorical_naive_bayes() {
         let x = DenseMatrix::from_2d_array(&[
@@ -431,6 +432,7 @@ mod tests {
         assert_eq!(y_hat, vec![0., 1.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_categorical_naive_bayes2() {
         let x = DenseMatrix::from_2d_array(&[
@@ -459,6 +461,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -259,6 +259,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_gaussian_naive_bayes() {
         let x = DenseMatrix::from_2d_array(&[
@@ -295,6 +296,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_gaussian_naive_bayes_with_priors() {
         let x = DenseMatrix::from_2d_array(&[
@@ -314,6 +316,7 @@ mod tests {
         assert_eq!(gnb.class_priors(), &priors);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -297,6 +297,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_multinomial_naive_bayes() {
         // Tests that MultinomialNB when alpha=1.0 gives the same values as
@@ -352,6 +353,7 @@ mod tests {
         assert_eq!(y_hat, &[0.]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn multinomial_nb_scikit_parity() {
         let x = DenseMatrix::<f64>::from_2d_array(&[
@@ -411,6 +413,7 @@ mod tests {
             1e-5
         ));
     }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -251,6 +251,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_fit_predict() {
         let x =
@@ -262,6 +263,7 @@ mod tests {
         assert_eq!(y.to_vec(), y_hat);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_fit_predict_weighted() {
         let x = DenseMatrix::from_2d_array(&[&[1.], &[2.], &[3.], &[4.], &[5.]]);
@@ -279,6 +281,7 @@ mod tests {
         assert_eq!(vec![3.0], y_hat);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -231,6 +231,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::DenseMatrix;
     use crate::math::distance::Distances;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_fit_predict_weighted() {
         let x =
@@ -254,6 +255,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn knn_fit_predict_uniform() {
         let x =
@@ -268,6 +270,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/optimization/first_order/gradient_descent.rs
+++ b/src/optimization/first_order/gradient_descent.rs
@@ -88,6 +88,7 @@ mod tests {
     use crate::optimization::line_search::Backtracking;
     use crate::optimization::FunctionOrder;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn gradient_descent() {
         let x0 = DenseMatrix::row_vector_from_array(&[-1., 1.]);

--- a/src/optimization/first_order/lbfgs.rs
+++ b/src/optimization/first_order/lbfgs.rs
@@ -239,6 +239,7 @@ mod tests {
     use crate::optimization::line_search::Backtracking;
     use crate::optimization::FunctionOrder;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn lbfgs() {
         let x0 = DenseMatrix::row_vector_from_array(&[0., 0.]);

--- a/src/optimization/line_search.rs
+++ b/src/optimization/line_search.rs
@@ -112,6 +112,7 @@ impl<T: Float> LineSearchMethod<T> for Backtracking<T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn backtracking() {
         let f = |x: f64| -> f64 { x.powf(2.) + x };

--- a/src/preprocessing/categorical.rs
+++ b/src/preprocessing/categorical.rs
@@ -225,6 +225,7 @@ mod tests {
     use crate::linalg::naive::dense_matrix::DenseMatrix;
     use crate::preprocessing::series_encoder::CategoryMapper;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn adjust_idxs() {
         assert_eq!(find_new_idxs(0, &[], &[]), Vec::<usize>::new());
@@ -269,6 +270,7 @@ mod tests {
         (orig, oh_enc)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn hash_encode_f64_series() {
         let series = vec![3.0, 1.0, 2.0, 1.0];
@@ -279,6 +281,7 @@ mod tests {
         let orig_val: f64 = inv.unwrap().into();
         assert_eq!(orig_val, 2.0);
     }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_fit() {
         let (x, _) = build_fake_matrix();
@@ -294,6 +297,7 @@ mod tests {
         assert_eq!(num_cat, vec![2, 4]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn matrix_transform_test() {
         let (x, expected_x) = build_fake_matrix();
@@ -309,6 +313,7 @@ mod tests {
         assert_eq!(nm, expected_x);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fail_on_bad_category() {
         let m = DenseMatrix::from_2d_array(&[

--- a/src/preprocessing/series_encoder.rs
+++ b/src/preprocessing/series_encoder.rs
@@ -201,6 +201,7 @@ where
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn from_categories() {
         let fake_categories: Vec<usize> = vec![1, 2, 3, 4, 5, 3, 5, 3, 1, 2, 4];
@@ -219,12 +220,14 @@ mod tests {
         let enc = CategoryMapper::<&str>::from_positional_category_vec(fake_category_pos);
         enc
     }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn ordinal_encoding() {
         let enc = build_fake_str_enc();
         assert_eq!(1f64, enc.get_ordinal::<f64>(&"dog").unwrap())
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn category_map_and_vec() {
         let category_map: HashMap<&str, usize> = vec![("background", 0), ("dog", 1), ("cat", 2)]
@@ -239,6 +242,7 @@ mod tests {
         assert_eq!(oh_vec, res);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn positional_categories_vec() {
         let enc = build_fake_str_enc();
@@ -250,6 +254,7 @@ mod tests {
         assert_eq!(oh_vec, res);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn invert_label_test() {
         let enc = build_fake_str_enc();
@@ -262,6 +267,7 @@ mod tests {
         };
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn test_many_categorys() {
         let enc = build_fake_str_enc();

--- a/src/svm/mod.rs
+++ b/src/svm/mod.rs
@@ -159,6 +159,7 @@ impl<T: RealNumber, V: BaseVector<T>> Kernel<T, V> for SigmoidKernel<T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn linear_kernel() {
         let v1 = vec![1., 2., 3.];
@@ -167,6 +168,7 @@ mod tests {
         assert_eq!(32f64, Kernels::linear().apply(&v1, &v2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn rbf_kernel() {
         let v1 = vec![1., 2., 3.];
@@ -175,6 +177,7 @@ mod tests {
         assert!((0.2265f64 - Kernels::rbf(0.055).apply(&v1, &v2)).abs() < 1e-4);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn polynomial_kernel() {
         let v1 = vec![1., 2., 3.];
@@ -186,6 +189,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn sigmoid_kernel() {
         let v1 = vec![1., 2., 3.];

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -729,6 +729,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use crate::svm::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn svc_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -771,6 +772,7 @@ mod tests {
         assert!(accuracy(&y_hat, &y) >= 0.9);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn svc_fit_predict_rbf() {
         let x = DenseMatrix::from_2d_array(&[
@@ -814,6 +816,7 @@ mod tests {
         assert!(accuracy(&y_hat, &y) >= 0.9);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn svc_serde() {

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -536,6 +536,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use crate::svm::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn svr_fit_predict() {
         let x = DenseMatrix::from_2d_array(&[
@@ -569,6 +570,7 @@ mod tests {
         assert!(mean_squared_error(&y_hat, &y) < 2.5);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn svr_serde() {

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -640,6 +640,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn gini_impurity() {
         assert!(
@@ -656,6 +657,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_predict_iris() {
         let x = DenseMatrix::from_2d_array(&[
@@ -708,6 +710,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_predict_baloons() {
         let x = DenseMatrix::from_2d_array(&[
@@ -744,6 +747,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -506,6 +506,7 @@ mod tests {
     use super::*;
     use crate::linalg::naive::dense_matrix::DenseMatrix;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn fit_longley() {
         let x = DenseMatrix::from_2d_array(&[
@@ -580,6 +581,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {


### PR DESCRIPTION
fixes  https://github.com/smartcorelib/smartcore/issues/93

Running the tests in the CI with wasm and solving the problems in the failing tests.

- [x] We should merge #95 first.

The more important changes in this PR are in the dataset mod, .github/ and Cargo.toml

The other files only are adding  #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)] in the tests.
