### PR TITLE
style(lint): fix clippy warnings

### DIFF
--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -316,8 +316,7 @@ impl<T: Debug + PartialEq, F: RealNumber, D: Distance<T, F>> CoverTree<T, F, D> 
                     point_set.append(&mut far);
                     child
                 } else {
-                    let mut children: Vec<Node<F>> = Vec::new();
-                    children.push(child);
+                    let mut children: Vec<Node<F>> = vec![child];
                     let mut new_point_set: Vec<DistanceSet<F>> = Vec::new();
                     let mut new_consumed_set: Vec<DistanceSet<F>> = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
     clippy::type_complexity,
     clippy::too_many_arguments,
     clippy::many_single_char_names,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::upper_case_acronyms
 )]
 #![warn(missing_docs)]
 #![warn(missing_doc_code_examples)]

--- a/src/linalg/naive/dense_matrix.rs
+++ b/src/linalg/naive/dense_matrix.rs
@@ -524,9 +524,9 @@ impl<T: RealNumber> PartialEq for DenseMatrix<T> {
     }
 }
 
-impl<T: RealNumber> Into<Vec<T>> for DenseMatrix<T> {
-    fn into(self) -> Vec<T> {
-        self.values
+impl<T: RealNumber> From<DenseMatrix<T>> for Vec<T> {
+    fn from(dense_matrix: DenseMatrix<T>) -> Vec<T> {
+        dense_matrix.values
     }
 }
 


### PR DESCRIPTION
Fix clippy warnings added when we are building this library with the latest stable version of Rust.