### PR TITLE
First draft of the new n-dimensional arrays + NB use case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["machine-learning", "statistical", "ai", "optimization", "linear-alg
 categories = ["science"]
 
 [features]
-default = ["datasets"]
+default = ["datasets", "serde"]
 ndarray-bindings = ["ndarray"]
 nalgebra-bindings = ["nalgebra"]
 datasets = []
@@ -25,6 +25,7 @@ num-traits = "0.2.12"
 num = "0.4.0"
 rand = "0.8.3"
 rand_distr = "0.4.0"
+approx = "0.4"
 serde = { version = "1.0.115", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,10 @@
 //! let y_hat = knn.predict(&x).unwrap();
 //! ```
 
+pub mod num;
+pub mod api;
 /// Various algorithms and helper methods that are used elsewhere in SmartCore
 pub mod algorithm;
-pub mod api;
 /// Algorithms for clustering of unlabeled data
 pub mod cluster;
 /// Various datasets
@@ -99,3 +100,5 @@ pub mod preprocessing;
 pub mod svm;
 /// Supervised tree-based learning methods
 pub mod tree;
+#[cfg(test)]
+pub mod utils;

--- a/src/linalg/base.rs
+++ b/src/linalg/base.rs
@@ -1,0 +1,891 @@
+use std::fmt;
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+use std::ops::Neg;
+use std::hash::Hash;
+use std::collections::HashMap;
+
+use num_traits::Signed;
+use crate::num::{Number, FloatNumber};
+
+pub trait Array<T: Debug + Display + Copy + Sized, S>: Debug {  
+    fn get(&self, pos: S) -> &T;
+
+    fn shape(&self) -> S;
+
+    fn is_empty(&self) -> bool;
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b>;        
+
+}
+
+pub trait MutArray<T: Debug + Display + Copy + Sized, S>: Array<T, S> {  
+    
+    fn set(&mut self, pos: S, x: T);  
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b>;  
+    
+    fn div_element_mut(&mut self, pos: S, x: T) where T: Number, S: Copy {
+        self.set(pos, *self.get(pos) / x);
+    }
+
+    fn mul_element_mut(&mut self, pos: S, x: T) where T: Number, S: Copy {
+        self.set(pos, *self.get(pos) * x);
+    }
+
+    fn add_element_mut(&mut self, pos: S, x: T) where T: Number, S: Copy {
+        self.set(pos, *self.get(pos) + x);
+    }
+
+    fn sub_element_mut(&mut self, pos: S, x: T) where T: Number, S: Copy {
+        self.set(pos, *self.get(pos) - x);
+    }
+
+    fn sub_scalar_mut(&mut self, x: T) where T: Number {
+        self.iterator_mut(0).for_each(|v| *v = *v - x);
+    }
+
+    fn add_scalar_mut(&mut self, x: T) where T: Number {
+        self.iterator_mut(0).for_each(|v| *v = *v + x);
+    }
+
+    fn mul_scalar_mut(&mut self, x: T) where T: Number {
+        self.iterator_mut(0).for_each(|v| *v = *v * x);        
+    }
+
+    fn div_scalar_mut(&mut self, x: T) where T: Number {
+        self.iterator_mut(0).for_each(|v| *v = *v / x);        
+    }   
+    
+    fn add_mut(&mut self, other: &dyn Array<T, S>) where T: Number, S: Eq {
+        assert!(self.shape() == other.shape(), "A and B should have the same shape");
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(a, &b)| *a = *a + b);        
+    }
+
+    fn sub_mut(&mut self, other: &dyn Array<T, S>) where T: Number, S: Eq {
+        assert!(self.shape() == other.shape(), "A and B should have the same shape");
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(a, &b)| *a = *a - b);
+        
+    }
+
+    fn mul_mut(&mut self, other: &dyn Array<T, S>) where T: Number, S: Eq {
+        assert!(self.shape() == other.shape(), "A and B should have the same shape");
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(a, &b)| *a = *a * b);
+        
+    }
+
+    fn div_mut(&mut self, other: &dyn Array<T, S>) where T: Number, S: Eq {
+        assert!(self.shape() == other.shape(), "A and B should have the same shape");
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(a, &b)| *a = *a / b);
+        
+    } 
+}
+
+pub trait ArrayView1<T: Debug + Display + Copy + Sized>: Array<T, usize> {     
+    
+    fn dot(&self, other: &dyn ArrayView1<T>) -> T where T: Number {
+        assert!(self.shape() == other.shape(), "Can't take dot product. Arrays have different shapes");
+        self.iterator(0).zip(other.iterator(0)).map(|(s, o)| *s * *o).sum()
+    } 
+
+    fn sum(&self) -> T where T: Number {
+        self.iterator(0).map(|v| *v).sum()
+    }    
+    
+    fn max(&self) -> T where T: FloatNumber {
+        self.iterator(0).fold(T::neg_infinity(), |max, x| T::max(max, *x))        
+    }
+
+    fn min(&self) -> T where T: FloatNumber {
+        self.iterator(0).fold(T::infinity(), |max, x| T::min(max, *x))
+    }
+
+    fn unique(&self) -> Vec<T> where T: Number + Ord {
+        let mut result: Vec<T> = self.iterator(0).map(|&v| v).collect();
+        result.sort();
+        result.dedup();
+        result
+    }
+
+    fn unique_with_indices(&self) -> (Vec<T>, Vec<usize>) where T: Number + Ord + Eq + Hash {
+        let mut unique: Vec<T> = self.iterator(0).map(|&v| v).collect();
+        unique.sort();
+        unique.dedup();
+
+        let mut index = HashMap::with_capacity(unique.len());
+        for (i, u) in unique.iter().enumerate() {
+            index.insert(u, i);
+        }
+
+        let mut unique_index = Vec::with_capacity(self.shape());
+        for idx in 0..self.shape() {
+            unique_index.push(index[&self.get(idx)]);
+        }
+
+        (unique, unique_index)
+    }
+
+    fn norm2(&self) -> T where T: FloatNumber {
+        self.iterator(0).fold(T::zero(), |norm, xi| norm + *xi * *xi).sqrt()        
+    }
+
+    fn norm(&self, p: T) -> T where T: FloatNumber {
+        if p.is_infinite() && p.is_sign_positive() {
+            self.iterator(0)                
+                .map(|x| x.abs())
+                .fold(T::neg_infinity(), |a, b| a.max(b))
+        } else if p.is_infinite() && p.is_sign_negative() {
+            self.iterator(0)                
+                .map(|x| x.abs())
+                .fold(T::infinity(), |a, b| a.min(b))
+        } else {
+            let mut norm = T::zero();
+
+            for xi in self.iterator(0) {
+                norm += xi.abs().powf(p);
+            }
+
+            norm.powf(T::one() / p)
+        }
+    }
+
+    fn var(&self) -> T where T: FloatNumber {
+        let n = self.shape();
+
+        let mut mu = T::zero();
+        let mut sum = T::zero();
+        let div = T::from_usize(n).unwrap();
+        for i in 0..n {
+            let xi = *self.get(i);
+            mu += xi;
+            sum += xi * xi;
+        }
+        mu /= div;
+        sum / div - mu.powi(2)
+    }
+
+    fn std(&self) -> T where T: FloatNumber {
+        self.var().sqrt()
+    }
+    
+}
+
+pub trait ArrayView2<T: Debug + Display + Copy + Sized>: Array<T, (usize, usize)> {
+    
+    fn max(&self, axis: u8) -> Vec<T> where T: Number + PartialOrd {
+        let (nrows, ncols) = self.shape();
+        let max_f = |max: T, r: usize, c: usize| -> T { 
+            let v = self.get((r, c));
+            match T::gt(v, &max) {
+                true => *v,
+                _ => max,
+            }
+        };
+        match axis {
+            0 => (0..ncols).map(move |c| (0..nrows).fold(T::min_value(), |max, r| max_f(max, r, c))).collect(),
+            _ => (0..nrows).map(move |r| (0..ncols).fold(T::min_value(), |max, c| max_f(max, r, c))).collect()
+        }        
+    }
+
+    fn sum(&self, axis: u8) -> Vec<T> where T: Number {
+        let (nrows, ncols) = self.shape();
+        match axis {
+            0 => (0..ncols).map(move |c| (0..nrows).map(|r| *self.get((r, c))).sum()).collect(),
+            _ => (0..nrows).map(move |r| (0..ncols).map(|c| *self.get((r, c))).sum()).collect()
+        }         
+    }
+
+    fn min(&self, axis: u8) -> Vec<T> where T: Number + PartialOrd {
+        let (nrows, ncols) = self.shape();
+        let min_f = |min: T, r: usize, c: usize| -> T { 
+            let v = self.get((r, c));
+            match T::lt(v, &min) {
+                true => *v,
+                _ => min,
+            }
+        };
+        match axis {
+            0 => (0..ncols).map(move |c| (0..nrows).fold(T::max_value(), |min, r| min_f(min, r, c))).collect(),
+            _ => (0..nrows).map(move |r| (0..ncols).fold(T::max_value(), |min, c| min_f(min, r, c))).collect()
+        } 
+    }    
+
+    fn mean(&self, axis: u8) -> Vec<f64> where T: Number {
+        let (n, m) = match axis {
+            0 => {
+                let (n, m) = self.shape();
+                (m, n)
+            }
+            _ => self.shape(),
+        };
+
+        let mut x: Vec<f64> = vec![0f64; n];
+
+        let div = m as f64;
+
+        for (i, x_i) in x.iter_mut().enumerate().take(n) {
+            for j in 0..m {
+                *x_i += match axis {
+                    0 => T::to_f64(self.get((j, i))).unwrap(),
+                    _ => T::to_f64(self.get((i, j))).unwrap(),
+                };
+            }
+            *x_i /= div;
+        }
+
+        x
+    }
+    
+    fn var(&self, axis: u8) -> Vec<f64> where T: Number {
+        let (n, m) = match axis {
+            0 => {
+                let (n, m) = self.shape();
+                (m, n)
+            }
+            _ => self.shape(),
+        };
+
+        let mut x: Vec<f64> = vec![0f64; n];
+
+        let div = m as f64;
+
+        for (i, x_i) in x.iter_mut().enumerate().take(n) {
+            let mut mu = 0f64;
+            let mut sum = 0f64;
+            for j in 0..m {
+                let a = match axis {
+                    0 => T::to_f64(self.get((j, i))).unwrap(),
+                    _ => T::to_f64(self.get((i, j))).unwrap(),
+                };
+                mu += a;
+                sum += a * a;
+            }
+            mu /= div;
+            *x_i = sum / div - mu.powi(2);
+        }
+
+        x
+    }
+    
+    fn std(&self, axis: u8) -> Vec<f64> where T: Number {
+        let mut x = self.var(axis);
+
+        let n = match axis {
+            0 => self.shape().1,
+            _ => self.shape().0,
+        };
+
+        for x_i in x.iter_mut().take(n) {
+            *x_i = x_i.sqrt();
+        }
+
+        x
+    }
+
+    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (nrows, ncols) = self.shape();
+        for r in 0..nrows {                        
+            let row: Vec<T> = (0..ncols).map(|c| *self.get((r, c))).collect();
+            writeln!(f, "{:?}", row)?            
+        }  
+        Ok(())        
+    }          
+    
+}
+
+pub trait MutArrayView1<T: Debug + Display + Copy + Sized>: MutArray<T, usize> + ArrayView1<T> {                      
+    
+    fn copy_from(&mut self, other: &dyn Array<T, usize>) {
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(s, o)| *s = *o);        
+    }   
+    
+    fn abs_mut(&mut self) where T: Number + Signed {
+        self.iterator_mut(0).for_each(|v| *v = v.abs());
+    }
+
+    fn neg_mut(&mut self) where T: Number + Neg<Output = T> {
+        self.iterator_mut(0).for_each(|v| *v = -*v);
+    }
+    
+}
+
+pub trait MutArrayView2<T: Debug + Display + Copy + Sized>: MutArray<T, (usize, usize)> + ArrayView2<T> {       
+    
+    fn copy_from(&mut self, other: &dyn Array<T, (usize, usize)>) {
+        self.iterator_mut(0).zip(other.iterator(0)).for_each(|(s, o)| *s = *o);        
+    } 
+
+    fn abs_mut(&mut self) where T: Number + Signed {
+        self.iterator_mut(0).for_each(|v| *v = v.abs());
+    }
+
+    fn neg_mut(&mut self) where T: Number + Neg<Output = T> {
+        self.iterator_mut(0).for_each(|v| *v = -*v);
+    }    
+    
+}
+
+pub trait Array1<T: Debug + Display + Copy + Sized>: MutArrayView1<T> + Sized + Clone {
+
+    fn slice<'a>(&'a self, range: Range<usize>) -> Box<dyn ArrayView1<T> + 'a>;     
+
+    fn slice_mut<'a>(&'a mut self, range: Range<usize>) -> Box<dyn MutArrayView1<T> + 'a>;     
+
+    fn fill(len: usize, value: T) -> Self; 
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, len: usize) -> Self where T: 'a;
+
+    fn from_vec_slice(slice: &[T]) -> Self;
+
+    fn from_slice(slice: &dyn ArrayView1<T>) -> Self;
+
+    fn zeros(len: usize) -> Self where T: Number {
+        Self::fill(len, T::zero())
+    }
+    fn ones(len: usize) -> Self where T: Number {
+        Self::fill(len, T::one())
+    }    
+
+    fn add_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.add_scalar_mut(x);
+        result       
+    }
+
+    fn sub_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.sub_scalar_mut(x);
+        result       
+    } 
+        
+    fn div_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.div_scalar_mut(x);
+        result       
+    } 
+    
+    fn mul_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.mul_scalar_mut(x);
+        result       
+    } 
+
+    fn add(&self, other: &dyn Array<T, usize>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.add_mut(other);
+        result       
+    }
+
+    fn sub(&self, other: &dyn Array<T, usize>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.sub_mut(other);
+        result       
+    }
+
+    fn mul(&self, other: &dyn Array<T, usize>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.mul_mut(other);
+        result       
+    }
+
+    fn div(&self, other: &dyn Array<T, usize>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.div_mut(other);
+        result       
+    }    
+
+    fn take(&self, index: &[usize]) -> Self {      
+        let len = self.shape();
+        assert!(index.iter().all(|&i| i < len), "All indices in `take` should be < {}", len);                        
+        Self::from_iterator(index.iter().map(move |&i| self.get(i)), index.len())            
+    }
+
+    fn abs(&self) -> Self where T: Number + Signed {
+        let mut result = self.clone();
+        result.abs_mut();
+        result       
+    } 
+
+    fn neg(&self) -> Self where T: Number + Neg<Output = T> {
+        let mut result = self.clone();
+        result.neg_mut();
+        result       
+    }
+
+}
+
+pub trait Array2<T: Debug + Display + Copy + Sized>: MutArrayView2<T> + Sized + Clone {
+
+    fn fill(nrows: usize, ncols: usize, value: T) -> Self;        
+
+    fn slice<'a>(&'a self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn ArrayView2<T> + 'a> where Self: Sized;
+
+    fn slice_mut<'a>(&'a mut self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn MutArrayView2<T> + 'a> where Self: Sized;
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, nrows: usize, ncols: usize, axis: u8) -> Self where T: 'a;
+
+    fn get_row<'a>(&'a self, row: usize) -> Box<dyn ArrayView1<T> + 'a> where Self: Sized;
+
+    fn get_col<'a>(&'a self, col: usize) -> Box<dyn ArrayView1<T> + 'a> where Self: Sized;
+
+    fn zeros(nrows: usize, ncols: usize) -> Self where T: Number {
+        Self::fill(nrows, ncols, T::zero())
+    }
+
+    fn ones(nrows: usize, ncols: usize) -> Self where T: Number {
+        Self::fill(nrows, ncols, T::one())
+    }
+
+    fn from_slice(slice: &dyn ArrayView2<T>) -> Self {
+        let (nrows, ncols) = slice.shape();
+        Self::from_iterator(slice.iterator(0), nrows, ncols, 0)
+    }
+
+    fn from_row(slice: &dyn ArrayView1<T>) -> Self {
+        let ncols = slice.shape();
+        Self::from_iterator(slice.iterator(0), 1, ncols, 0)
+    }
+
+    fn from_column(slice: &dyn ArrayView1<T>) -> Self {
+        let nrows = slice.shape();
+        Self::from_iterator(slice.iterator(0), nrows, 1, 0)
+    }        
+
+    fn transpose(&self) -> Self {
+        let (nrows, ncols) = self.shape();
+        let mut m = Self::fill(ncols, nrows, *self.get((0, 0)));
+        for c in 0..ncols {
+            for r in 0..nrows {
+                m.set((c, r), *self.get((r, c)));
+            }
+        }
+        m
+    }
+
+    fn reshape(&self, nrows: usize, ncols: usize, axis: u8) -> Self {
+
+        let (onrows, oncols) = self.shape();
+
+        assert!(nrows * ncols == onrows * oncols, "Can't reshape {}x{} array into a {}x{} array", onrows, oncols, nrows, ncols);
+
+        Self::from_iterator(self.iterator(0), nrows, ncols, axis)
+    }
+
+    fn matmul(&self, other: &dyn ArrayView2<T>) -> Self where T: Number {        
+        let (nrows, ncols) = self.shape();
+        let (o_nrows, o_ncols) = other.shape();
+        if ncols != o_nrows {
+            panic!("Number of rows of A should equal number of columns of B");
+        }
+        let inner_d = ncols;
+        let mut result = Self::zeros(nrows, o_ncols);
+
+        for r in 0..nrows {
+            for c in 0..o_ncols {
+                let mut s = T::zero();
+                for i in 0..inner_d {
+                    s += *self.get((r, i)) * *other.get((i, c));
+                }
+                result.set((r, c), s);
+            }
+        }
+
+        result
+    }   
+    
+    fn cancatenate_1d<'a>(arrays: &'a [Box<dyn ArrayView1<T> + 'a>], axis: u8) -> Self {
+
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        assert!(arrays.len() > 0, "Can't concatenate an empty array");
+        assert!(arrays.windows(2).all(|w| w[0].shape() == w[1].shape()), "Can't concatenate arrays of different sizes");
+
+        let first = &arrays[0];
+        let tail = &arrays[1..];
+        
+        match axis {
+            0 => Self::from_iterator(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0)))), arrays.len(), arrays[0].shape(), axis),
+            _ => Self::from_iterator(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0)))), arrays[0].shape(), arrays.len(), axis)
+        }
+    }
+
+    fn cancatenate_2d<A: ArrayView2<T>>(arrays: &[&A], axis: u8) -> Self {
+
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        assert!(arrays.len() > 0, "Can't concatenate an empty array");
+        if axis == 0 {
+            assert!(arrays.windows(2).all(|w| w[0].shape().1 == w[1].shape().1), "Number of columns in all arrays should match");
+        } else {
+            assert!(arrays.windows(2).all(|w| w[0].shape().0 == w[1].shape().0), "Number of rows in all arrays should match");
+        }
+
+        let first = arrays[0];
+        let tail = &arrays[1..];
+        
+        match axis {
+            0 => {
+                let (nrows, ncols) = (arrays.iter().map(|&a| a.shape().0).sum(), arrays[0].shape().1);
+                Self::from_iterator(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0)))), nrows, ncols, axis)
+            },
+            _ => {
+                let (nrows, ncols) = (arrays[0].shape().0, (arrays.iter().map(|&a| a.shape().1).sum()));                
+                Self::from_iterator(tail.iter().fold(first.iterator(1), |acc, i| Box::new(acc.chain(i.iterator(1)))), nrows, ncols, axis)
+            }
+        }
+    }
+
+    fn merge_1d<A: ArrayView1<T>>(&self, arrays: &[&A], axis: u8, append: bool) -> Self {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        assert!(arrays.len() > 0, "Can't merge with an empty array");
+
+        let first = arrays[0];
+        let tail = &arrays[1..];
+
+        match (append, axis) {
+            (true, 0) => {
+                let (nrows, ncols) = (self.shape().0 + arrays.len(), self.shape().1);
+                Self::from_iterator(self.iterator(0).chain(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0))))), nrows, ncols, axis)                
+            },
+            (true, 1) => {
+                let (nrows, ncols) = (self.shape().0, self.shape().1 + arrays.len());
+                Self::from_iterator(self.iterator(1).chain(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0))))), nrows, ncols, axis)
+            },
+            (false, 0) => {
+                let (nrows, ncols) = (self.shape().0 + arrays.len(), self.shape().1);
+                Self::from_iterator(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0)))).chain(self.iterator(0)), nrows, ncols, axis) 
+            },
+            _ => {
+                let (nrows, ncols) = (self.shape().0, self.shape().1 + arrays.len());
+                Self::from_iterator(tail.iter().fold(first.iterator(0), |acc, i| Box::new(acc.chain(i.iterator(0)))).chain(self.iterator(1)), nrows, ncols, axis)
+            }
+        }        
+    }
+
+    fn row_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Box<dyn ArrayView1<T> + 'a>> + 'a> {        
+        Box::new((0..self.shape().0).map(move |r| self.get_row(r)))
+    }
+
+    fn col_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Box<dyn ArrayView1<T> + 'a>> + 'a> {        
+        Box::new((0..self.shape().1).map(move |r| self.get_col(r)))
+    }
+    
+    fn take(&self, index: &[usize], axis: u8) -> Self {       
+
+        let (nrows, ncols) = self.shape();                
+        
+        match axis {
+            0 => {
+                assert!(index.iter().all(|&i| i < nrows), "All indices in `take` should be < {}", nrows);     
+                Self::from_iterator(index.iter().flat_map(move |&r| (0..ncols).map(move |c| self.get((r, c)))), index.len(), ncols, 0)
+            },
+            _ => {
+                assert!(index.iter().all(|&i| i < ncols), "All indices in `take` should be < {}", ncols);     
+                Self::from_iterator((0..nrows).flat_map(move |r| index.iter().map(move |&c| self.get((r, c)))), nrows, index.len(), 0)
+            }
+        }        
+            
+    }
+
+    fn add_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.add_scalar_mut(x);
+        result       
+    }
+
+    fn sub_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.sub_scalar_mut(x);
+        result       
+    } 
+        
+    fn div_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.div_scalar_mut(x);
+        result       
+    } 
+    
+    fn mul_scalar(&self, x: T) -> Self where T: Number {
+        let mut result = self.clone();
+        result.mul_scalar_mut(x);
+        result       
+    } 
+
+    fn add(&self, other: &dyn Array<T, (usize, usize)>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.add_mut(other);
+        result       
+    }
+
+    fn sub(&self, other: &dyn Array<T, (usize, usize)>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.sub_mut(other);
+        result       
+    }
+
+    fn mul(&self, other: &dyn Array<T, (usize, usize)>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.mul_mut(other);
+        result       
+    }
+
+    fn div(&self, other: &dyn Array<T, (usize, usize)>) -> Self where T: Number {
+        let mut result = self.clone();
+        result.div_mut(other);
+        result       
+    } 
+
+    fn abs(&self) -> Self where T: Number + Signed {
+        let mut result = self.clone();
+        result.abs_mut();
+        result       
+    } 
+
+    fn neg(&self) -> Self where T: Number + Neg<Output = T> {
+        let mut result = self.clone();
+        result.neg_mut();
+        result       
+    } 
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;  
+    use crate::linalg::dense::matrix::DenseMatrix;    
+    
+    #[test]
+    fn test_dot() {        
+        let a = vec![1, 2, 3];
+        let b = vec![1.0, 2.0, 3.0];                
+        let c = vec![4.0, 5.0, 6.0];
+
+        assert_eq!(b.slice(0..2).dot(c.slice(0..2).as_ref()), 14.);
+        assert_eq!(b.slice(0..3).dot(&c), 32.);
+        assert_eq!(b.dot(&c), 32.);
+        assert_eq!(a.dot(&a), 14);       
+    }
+    
+    #[test]
+    #[should_panic]
+    fn test_failed_dot() {        
+        let a = vec![1, 2, 3];
+        
+        a.slice(0..2).dot(a.slice(0..3).as_ref());
+        
+    }
+
+    #[test]
+    fn test_vec_chaining() {
+        let mut x: Vec<i32> = Vec::zeros(6);
+        
+        x.add_scalar(5);
+        assert_eq!(vec!(5, 5, 5, 5, 5, 5), x.add_scalar(5));
+        {
+            let mut x_s = x.slice_mut(0..3);
+            x_s.add_scalar_mut(1);
+        }        
+
+        assert_eq!(vec!(1, 1, 1, 0, 0, 0), x);
+    }    
+
+    #[test]
+    fn test_vec_norm() {
+        let v = vec![3., -2., 6.];
+        assert_eq!(v.norm(1.), 11.);
+        assert_eq!(v.norm(2.), 7.);
+        assert_eq!(v.norm(std::f64::INFINITY), 6.);
+        assert_eq!(v.norm(std::f64::NEG_INFINITY), 2.);        
+    }
+
+    #[test]
+    fn test_vec_unique() {
+        assert_eq!(vec![1, 2, 2, 3, 2, 1].unique(), vec![1, 2, 3]);
+        assert_eq!(Vec::<i32>::zeros(100).unique(), vec![0]);
+        assert_eq!(Vec::<i32>::zeros(100).slice(0..10).unique(), vec![0]);
+    }
+
+    #[test]
+    fn test_vec_var_std() {
+        assert_eq!(vec![1., 2., 3., 4., 5.].var(), 2.);
+        assert_eq!(vec![1., 2.].std(), 0.5);
+        assert_eq!(vec![1.].var(), 0.0);
+        assert_eq!(vec![1.].std(), 0.0);
+    }
+
+    #[test]
+    fn test_vec_abs() {
+        let mut x = vec![-1, 2, -3];
+        x.abs_mut();
+        assert_eq!(x, vec![1, 2, 3]);        
+    }
+
+    #[test]
+    fn test_vec_neg() {
+        let mut x = vec![-1, 2, -3];
+        x.neg_mut();
+        assert_eq!(x, vec![1, -2, 3]);        
+    }
+
+    #[test]
+    fn test_vec_copy_from() {
+        let x = vec![1, 2, 3];
+        let mut y = Vec::<i32>::zeros(3);
+        y.copy_from(&x);
+        assert_eq!(y, vec![1, 2, 3]);        
+    }
+
+    #[test]
+    fn test_vec_element_ops() {
+        let mut x = vec![1, 2, 3, 4];
+        x.slice_mut(0..1).mul_element_mut(0, 4);
+        x.slice_mut(1..2).add_element_mut(0, 1);
+        x.slice_mut(2..3).sub_element_mut(0, 1);
+        x.slice_mut(3..4).div_element_mut(0, 4);
+        assert_eq!(x, vec![4, 3, 2, 1]);        
+    }
+
+    #[test]
+    fn test_vec_ops() {                
+        assert_eq!(vec![1, 2, 3, 4].mul_scalar(2), vec![2, 4, 6, 8]);
+        assert_eq!(vec![1, 2, 3, 4].add_scalar(2), vec![3, 4, 5, 6]);
+        assert_eq!(vec![1, 2, 3, 4].sub_scalar(1), vec![0, 1, 2, 3]);
+        assert_eq!(vec![1, 2, 3, 4].div_scalar(2), vec![0, 1, 1, 2]);        
+    }
+
+    #[test]
+    fn test_vec_init() {                
+        assert_eq!(Vec::<i32>::ones(3), vec![1, 1, 1]);
+        assert_eq!(Vec::<i32>::zeros(3), vec![0, 0, 0]);        
+    }
+
+    #[test]
+    fn test_vec_take() {                
+        assert_eq!(vec![1, 2, 3, 4, 5, 6].take(&[0, 4, 5]), vec![1, 5, 6]);               
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_vec_take() {                
+        assert_eq!(vec![1, 2, 3, 4, 5, 6].take(&[10, 4, 5]), vec![1, 5, 6]);               
+    }
+
+    #[test]
+    fn test_min_max() {        
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]).max(0), vec!(4, 5, 6));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]).max(1), vec!(3, 6));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]).min(0), vec!(1., 2., 3.));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]).min(1), vec!(1., 4.));
+    }
+
+    #[test]
+    fn test_sum() {        
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]).sum(0), vec!(5, 7, 9));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]).sum(1), vec!(6., 15.));        
+    }
+
+    #[test]
+    fn test_abs() {
+        let mut x = DenseMatrix::from_2d_array(&[&[-1, 2, -3], &[4, -5, 6]]);
+        x.abs_mut();
+        assert_eq!(x, DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]));
+    }
+
+    #[test]
+    fn test_neg() {
+        let mut x = DenseMatrix::from_2d_array(&[&[-1, 2, -3], &[4, -5, 6]]);
+        x.neg_mut();
+        assert_eq!(x, DenseMatrix::from_2d_array(&[&[1, -2, 3], &[-4, 5, -6]]));        
+    }
+
+    #[test]
+    fn test_copy_from() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);
+        let mut y = DenseMatrix::<i32>::zeros(2, 3);
+        y.copy_from(&x);
+        assert_eq!(y, DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]));        
+    }
+
+    #[test]
+    fn test_init() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);
+        assert_eq!(DenseMatrix::<i32>::zeros(2, 2), DenseMatrix::from_2d_array(&[&[0, 0], &[0, 0]]));
+        assert_eq!(DenseMatrix::<i32>::ones(2, 2), DenseMatrix::from_2d_array(&[&[1, 1], &[1, 1]]));        
+        assert_eq!(DenseMatrix::from_slice(x.slice(0..2, 0..2).as_ref()), DenseMatrix::from_2d_array(&[&[1, 2], &[4, 5]]));
+        assert_eq!(DenseMatrix::from_row(x.get_row(0).as_ref()), DenseMatrix::from_2d_array(&[&[1, 2, 3]]));        
+        assert_eq!(DenseMatrix::from_column(x.get_col(0).as_ref()), DenseMatrix::from_2d_array(&[&[1], &[4]]));
+    }
+
+    #[test]
+    fn test_transpose() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);        
+        assert_eq!(x.transpose(), DenseMatrix::from_2d_array(&[&[1, 4], &[2, 5], &[3, 6]]));
+    }
+
+    #[test]
+    fn test_reshape() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);        
+        assert_eq!(x.reshape(3, 2, 0), DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6]]));
+        assert_eq!(x.reshape(3, 2, 1), DenseMatrix::from_2d_array(&[&[1, 4], &[2, 5], &[3, 6]]));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_reshape() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);        
+        assert_eq!(x.reshape(4, 2, 0), DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6]]));        
+    }
+
+    #[test]
+    fn test_matmul() { 
+        let a = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);
+        let b = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6]]);        
+        assert_eq!(a.matmul(&(*b.slice(0..3, 0..2))), DenseMatrix::from_2d_array(&[&[22, 28], &[49, 64]]));
+        assert_eq!(a.matmul(&b), DenseMatrix::from_2d_array(&[&[22, 28], &[49, 64]]));        
+    }
+
+    #[test]
+    fn test_concat() {  
+        let a = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]); 
+        let b = DenseMatrix::from_2d_array(&[&[5, 6], &[7, 8]]);        
+
+        assert_eq!(DenseMatrix::cancatenate_1d(&[Box::new(vec!(1, 2, 3)), Box::new(vec!(4, 5, 6))], 0),
+         DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]));
+        assert_eq!(DenseMatrix::cancatenate_1d(&[Box::new(vec!(1, 2)), Box::new(vec!(3, 4))], 1),
+         DenseMatrix::from_2d_array(&[&[1, 3], &[2, 4]]));
+        assert_eq!(DenseMatrix::cancatenate_2d(&[&a, &b], 0),
+         DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6], &[7, 8]]));
+        assert_eq!(DenseMatrix::cancatenate_2d(&[&a, &b], 1),
+         DenseMatrix::from_2d_array(&[&[1, 2, 5, 6], &[3, 4, 7, 8]]));        
+    }
+
+    #[test]
+    fn test_take() {  
+        let a = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);
+        let b = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6]]);        
+        
+        assert_eq!(a.take(&[0, 2], 1), DenseMatrix::from_2d_array(&[&[1, 3], &[4, 6]]));
+        assert_eq!(b.take(&[0, 2], 0), DenseMatrix::from_2d_array(&[&[1, 2], &[5, 6]]));
+    }
+
+    #[test]
+    fn test_merge() {  
+        let a = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]);         
+        
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6], &[7, 8]]),
+         a.merge_1d(&[&vec!(5, 6), &vec!(7, 8)], 0, true));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[5, 6], &[7, 8], &[1, 2], &[3, 4]]),
+         a.merge_1d(&[&vec!(5, 6), &vec!(7, 8)], 0, false));          
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2, 5, 7], &[3, 4, 6, 8]]),
+         a.merge_1d(&[&vec!(5, 6), &vec!(7, 8)], 1, true));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[5, 7, 1, 2], &[6, 8, 3, 4]]),
+         a.merge_1d(&[&vec!(5, 6), &vec!(7, 8)], 1, false));      
+    }
+
+    #[test]
+    fn test_ops() {                
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]).mul_scalar(2), DenseMatrix::from_2d_array(&[&[2, 4], &[6, 8]]));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]).add_scalar(2), DenseMatrix::from_2d_array(&[&[3, 4], &[5, 6]]));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]).sub_scalar(1), DenseMatrix::from_2d_array(&[&[0, 1], &[2, 3]]));
+        assert_eq!(DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]).div_scalar(2), DenseMatrix::from_2d_array(&[&[0, 1], &[1, 2]]));
+    }
+
+}

--- a/src/linalg/dense/matrix.rs
+++ b/src/linalg/dense/matrix.rs
@@ -1,0 +1,580 @@
+use std::fmt;
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use approx::{RelativeEq, AbsDiffEq};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::num::FloatNumber;
+use crate::linalg::base::{Array, MutArray, ArrayView1, ArrayView2, MutArrayView2, Array1, Array2};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DenseMatrix<T> {
+    ncols: usize,
+    nrows: usize,
+    values: Vec<T>,
+    column_major: bool
+}
+
+
+#[derive(Debug, Clone)]
+pub struct DenseMatrixView<'a, T: Debug + Display + Copy + Sized> {
+    values: &'a [T],
+    stride: usize,
+    nrows: usize,
+    ncols: usize,
+    column_major: bool
+}
+
+#[derive(Debug)]
+pub struct DenseMatrixMutView<'a, T: Debug + Display + Copy + Sized> {
+    values: &'a mut [T],
+    stride: usize,
+    nrows: usize,
+    ncols: usize,
+    column_major: bool
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> DenseMatrixView<'a, T> {
+    fn new(m: &'a DenseMatrix<T>, rows: Range<usize>, cols: Range<usize>) -> Self{
+        let (start, end, stride) = if m.column_major {
+            (rows.start + cols.start * m.nrows,
+            rows.end + (cols.end-1) * m.nrows,
+            m.nrows)
+        } else {
+            (rows.start * m.ncols + cols.start,
+                (rows.end-1) * m.ncols + cols.end,
+                m.ncols)
+        };
+        let view = DenseMatrixView{
+            values: &m.values[start..end],
+            stride,
+            nrows: rows.end - rows.start,  
+            ncols: cols.end - cols.start,
+            column_major: m.column_major          
+        };
+        view
+    }
+
+    fn iter<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new((0..self.nrows).flat_map(move |r| (0..self.ncols).map(move |c| self.get((r, c))) )),
+            _ => Box::new((0..self.ncols).flat_map(move |c| (0..self.nrows).map(move |r| self.get((r, c))) ))
+        }        
+    }    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> fmt::Display for DenseMatrixView<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display(f)       
+    }
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> DenseMatrixMutView<'a, T> {
+    fn new(m: &'a mut DenseMatrix<T>, rows: Range<usize>, cols: Range<usize>) -> Self{
+        let (start, end, stride) = if m.column_major {
+            (rows.start + cols.start * m.nrows,
+            rows.end + (cols.end-1) * m.nrows,
+            m.nrows)
+        } else {
+            (rows.start * m.ncols + cols.start,
+                (rows.end-1) * m.ncols + cols.end,
+                m.ncols)
+        };        
+        let view = DenseMatrixMutView{
+            values: &mut m.values[start..end],
+            stride: stride,
+            nrows: rows.end - rows.start,  
+            ncols: cols.end - cols.start,
+            column_major: m.column_major           
+        };
+        view
+    }
+
+    fn iter<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new((0..self.nrows).flat_map(move |r| (0..self.ncols).map(move |c| self.get((r, c))) )),
+            _ => Box::new((0..self.ncols).flat_map(move |c| (0..self.nrows).map(move |r| self.get((r, c))) ))
+        }
+    }
+
+    fn iter_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &mut T> + 'b>{        
+        let column_major = self.column_major;
+        let stride = self.stride;
+        let ptr = self.values.as_mut_ptr();
+        match axis {
+            0 => {
+                Box::new((0..self.nrows).flat_map(move |r| (0..self.ncols).map(
+                    move |c|
+                     unsafe {
+                          &mut *ptr.add(if column_major {r + c * stride} else {r * stride + c})})))
+            },
+            _ => {
+                Box::new((0..self.ncols).flat_map(move |c| (0..self.nrows).map(
+                    move |r|
+                     unsafe {
+                          &mut *ptr.add(if column_major {r + c * stride} else {r * stride + c})})))
+            }
+        }  
+    }
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> fmt::Display for DenseMatrixMutView<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display(f)       
+    }
+}
+
+impl<T: Debug + Display + Copy + Sized> DenseMatrix<T> {
+    /// Create new instance of `DenseMatrix` without copying data.
+    /// `values` should be in column-major order.
+    pub fn new(nrows: usize, ncols: usize, values: Vec<T>, column_major: bool) -> Self {
+        DenseMatrix {
+            ncols,
+            nrows,
+            values,
+            column_major
+        }
+    }
+
+    /// New instance of `DenseMatrix` from 2d array.
+    pub fn from_2d_array(values: &[&[T]]) -> Self {
+        DenseMatrix::from_2d_vec(&values.iter().map(|row| Vec::from(*row)).collect())
+    }
+
+    /// New instance of `DenseMatrix` from 2d vector.
+    pub fn from_2d_vec(values: &Vec<Vec<T>>) -> Self {
+        let nrows = values.len();
+        let ncols = values
+            .first()
+            .unwrap_or_else(|| panic!("Cannot create 2d matrix from an empty vector"))
+            .len();
+        let mut m_values = Vec::with_capacity(nrows * ncols);
+
+        for c in 0..ncols {
+            for r in 0..nrows {
+                m_values.push(values[r][c])
+            }
+        }
+
+        DenseMatrix::new(nrows, ncols, m_values, true)        
+    }
+}
+
+impl<T: Debug + Display + Copy + Sized> fmt::Display for DenseMatrix<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display(f)       
+    }
+}
+
+impl<T: Debug + Display + Copy + Sized + PartialEq> PartialEq for DenseMatrix<T> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.ncols != other.ncols || self.nrows != other.nrows {
+            return false;
+        }
+
+        let len = self.values.len();
+        let other_len = other.values.len();
+
+        if len != other_len {
+            return false;
+        }
+
+        match self.column_major == other.column_major {
+            true => self.values.iter().zip(other.values.iter()).all(|(&v1, v2)| v1.eq(v2)),
+            false => self.iterator(0).zip(other.iterator(0)).all(|(&v1, v2)| v1.eq(v2))
+        }
+    }
+}
+
+impl<T: FloatNumber + AbsDiffEq> AbsDiffEq for DenseMatrix<T> where
+    T::Epsilon: Copy,
+{
+    type Epsilon = T::Epsilon;
+
+    fn default_epsilon() -> T::Epsilon {
+        T::default_epsilon()
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
+        if self.ncols != other.ncols || self.nrows != other.nrows {
+            false
+        } else {
+            self.values.iter().zip(other.values.iter()).all(|(v1, v2)| T::abs_diff_eq(v1, v2, epsilon))
+        }
+    }
+}
+
+impl<T: FloatNumber + RelativeEq> RelativeEq for DenseMatrix<T> where
+    T::Epsilon: Copy,
+{
+    fn default_max_relative() -> T::Epsilon {
+        T::default_max_relative()
+    }
+
+    fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
+        if self.ncols != other.ncols || self.nrows != other.nrows {
+            false
+        } else {
+            self.values.iter().zip(other.values.iter()).all(|(v1, v2)| T::relative_eq(v1, v2, epsilon, max_relative))
+        }
+    }
+}
+
+impl<T: Debug + Display + Copy + Sized> Array<T, (usize, usize)> for DenseMatrix<T> {    
+
+    fn get(&self, pos: (usize, usize)) -> &T {
+        let (row, col) = pos;
+        if row >= self.nrows || col >= self.ncols {
+            panic!(
+                "Invalid index ({},{}) for {}x{} matrix",
+                row, col, self.nrows, self.ncols
+            );
+        }
+        if self.column_major{
+            &self.values[col * self.nrows + row]
+        } else {
+            &self.values[col + self.ncols * row]
+        }
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows, self.ncols)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.ncols > 0 && self.ncols > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new((0..self.nrows).flat_map(move |r| (0..self.ncols).map(move |c| self.get((r, c))) )),
+            _ => Box::new((0..self.ncols).flat_map(move |c| (0..self.nrows).map(move |r| self.get((r, c))) ))
+        }
+    }
+
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArray<T, (usize, usize)> for DenseMatrix<T> {    
+
+    fn set(&mut self, pos: (usize, usize), x: T) {
+        if self.column_major {
+            self.values[pos.1 * self.nrows + pos.0] = x;
+        } else {
+            self.values[pos.1 + pos.0 * self.ncols] = x;
+        }
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        let ptr = self.values.as_mut_ptr();
+        let column_major = self.column_major;
+        let (nrows, ncols) = self.shape();
+        match axis {
+            0 => {
+                Box::new((0..self.nrows).flat_map(move |r| (0..self.ncols).map(
+                    move |c|
+                     unsafe {
+                          &mut *ptr.add(if column_major {r + c * nrows} else {r * ncols + c})})))
+            },
+            _ => {
+                Box::new((0..self.ncols).flat_map(move |c| (0..self.nrows).map(
+                    move |r|
+                     unsafe {
+                          &mut *ptr.add(if column_major {r + c * nrows} else {r * ncols + c})})))
+            }
+        }
+    }
+
+}
+
+impl<T: Debug + Display + Copy + Sized> ArrayView2<T> for DenseMatrix<T> {    
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArrayView2<T> for DenseMatrix<T> {            
+}
+
+impl<T: Debug + Display + Copy + Sized> Array2<T> for DenseMatrix<T> {     
+    
+    fn get_row<'a>(&'a self, row: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(DenseMatrixView::new(self, row..row+1, 0..self.ncols))
+    }
+
+    fn get_col<'a>(&'a self, col: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(DenseMatrixView::new(self, 0..self.nrows, col..col+1))
+    }
+
+    fn slice<'a>(&'a self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn ArrayView2<T> + 'a> {
+        Box::new(DenseMatrixView::new(self, rows, cols))
+    }
+
+    fn slice_mut<'a>(&'a mut self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn MutArrayView2<T> + 'a> where Self: Sized {
+        Box::new(DenseMatrixMutView::new(self, rows, cols))
+    }
+
+    fn fill(nrows: usize, ncols: usize, value: T) -> Self {        
+        DenseMatrix::new(nrows, ncols, vec![value; nrows * ncols], true)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, nrows: usize, ncols: usize, axis: u8) -> Self where T: 'a {        
+        DenseMatrix::new(nrows, ncols, iter.map(|&x| x).collect(), if axis == 0 {false} else {true})
+    }    
+
+    fn transpose(&self) -> Self {
+        let mut m = self.clone();
+        m.ncols = self.nrows;
+        m.nrows = self.ncols;
+        m.column_major = !self.column_major;
+        m
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> Array<T, (usize, usize)> for DenseMatrixView<'a, T> {    
+
+    fn get(&self, pos: (usize, usize)) -> &T {     
+        if self.column_major {   
+            &self.values[(pos.0 + pos.1 * self.stride)]
+        } else {
+            &self.values[(pos.0* self.stride  + pos.1)]
+        }
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows, self.ncols)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.nrows * self.ncols > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        self.iter(axis)
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> Array<T, usize> for DenseMatrixView<'a, T> {    
+    
+    fn get(&self, i: usize) -> &T {          
+        if self.nrows == 1 {
+            if self.column_major  { &self.values[i * self.stride] } else { &self.values[i] }
+        } else if self.ncols == 1 || (!self.column_major && self.nrows == 1)  {
+            if self.column_major  { &self.values[i] } else { &self.values[i * self.stride] }            
+        } else {
+            panic!("This is neither a column nor a row");
+        }
+    }
+
+    fn shape(&self) -> usize {
+        if self.nrows == 1{
+            self.ncols
+        } else if self.ncols == 1{
+            self.nrows
+        } else {
+            panic!("This is neither a column nor a row");
+        }
+    }
+
+    fn is_empty(&self) -> bool{
+        self.nrows * self.ncols > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        self.iter(axis)
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView2<T> for DenseMatrixView<'a, T> {
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for DenseMatrixView<'a, T> {            
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> Array<T, (usize, usize)> for DenseMatrixMutView<'a, T> {    
+
+    fn get(&self, pos: (usize, usize)) -> &T {        
+        if self.column_major {
+            &self.values[(pos.0 + pos.1 * self.stride)]
+        } else {
+            &self.values[(pos.0 * self.stride + pos.1)]
+        }
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows, self.ncols)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.nrows * self.ncols > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        self.iter(axis)
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArray<T, (usize, usize)> for DenseMatrixMutView<'a, T> {    
+
+    fn set(&mut self, pos: (usize, usize), x: T){
+        if self.column_major {
+            self.values[(pos.0 + pos.1 * self.stride)] = x;
+        } else {
+            self.values[(pos.0 * self.stride + pos.1)] = x;
+        }
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b>{
+        self.iter_mut(axis)
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArrayView2<T> for DenseMatrixMutView<'a, T> {       
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView2<T> for DenseMatrixMutView<'a, T> {       
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; 
+    use crate::linalg::base::*;    
+    use approx::relative_eq;
+
+    fn test_func<A: Array2<i32>>() -> A{
+        A::cancatenate_2d(&[&A::zeros(10, 2), &A::zeros(10, 2)], 1)
+    }
+
+    #[test]
+    fn test_get_row_col() {
+        let x = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);
+
+        println!("{:?}", x.get_col(1).sum());
+        println!("{:?}", x.get_row(1).sum());
+
+        println!("{:?}", x.get_col(1).dot(&(*x.get_row(1))));
+    }
+
+    #[test]
+    fn test_row_major() {
+        let mut x = DenseMatrix::new(2, 3, vec!(1, 2, 3, 4, 5, 6), false);
+        
+        println!("{:?}", x.get_col(1).get(1));
+        println!("{:?}", x.get_col(1).sum());
+        println!("{:?}", x.get_row(1).get(1));
+        println!("{:?}", x.get_row(1).sum());
+        x.slice_mut(0..2, 1..2).iterator_mut(0).for_each(|v| *v += 2);
+        println!("{}", x);
+    }
+
+    #[test]
+    fn test_get_slice() {
+        let x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9], &[10, 11, 12]]);    
+        
+        println!("{}", DenseMatrix::from_slice(&(*x.slice(1..2, 0..3)))); 
+        let second_row: Vec<i32> = x.slice(1..2, 0..3).iterator(0).map(|x| *x).collect();
+        println!("{:?}", second_row); 
+        let second_col: Vec<i32> = x.slice(0..3, 1..2).iterator(0).map(|x| *x).collect();
+        println!("{:?}", second_col); 
+    }
+
+    #[test]
+    fn test_iter_mut() {
+        let mut x = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);    
+        
+        println!("{:?}", x); 
+        x.slice_mut(1..2, 0..3).iterator_mut(0).for_each(|v| *v += 2);
+        x.slice_mut(0..3, 1..2).iterator_mut(0).for_each(|v| *v += 1);
+        println!("{:?}", x); 
+        x.iterator_mut(1).enumerate().for_each(|(a, b)| *b = a);
+        println!("{}", x); 
+        x.iterator_mut(0).enumerate().for_each(|(a, b)| *b = a);
+        println!("{}", x); 
+        x.slice_mut(0..3, 0..2).iterator_mut(0).enumerate().for_each(|(a, b)| *b = a);
+        println!("{}", x); 
+        x.slice_mut(0..2, 0..3).iterator_mut(1).enumerate().for_each(|(a, b)| *b = a);
+        println!("{}", x); 
+    }
+
+    #[test]
+    fn test_str_array() {
+        let mut x = DenseMatrix::from_2d_array(&[&["1", "2", "3"], &["4", "5", "6"], &["7", "8", "9"]]);    
+        
+        println!("{:?}", x); 
+        x.iterator_mut(0).for_each(|v| *v = "str");        
+        println!("{:?}", x); 
+    }
+
+    #[test]
+    fn test_transpose() {
+        let x = DenseMatrix::from_2d_array(&[&["1", "2", "3"], &["4", "5", "6"]]);    
+        
+        println!("{:?}", x);         
+        println!("{:?}", x.transpose()); 
+    }    
+
+    #[test]
+    fn test_from_iterator() {        
+        let data = vec![1, 2, 3, 4, 5, 6];
+        
+        println!("{}", DenseMatrix::from_iterator(data.iter(), 2, 3, 0));
+    }
+
+    #[test]
+    fn test_merge() {        
+        let a = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4]]);           
+        
+        println!("{}", a.merge_1d(&[&vec!(5, 6), &vec!(7, 8)], 0, false));
+        println!("{}", a.merge_1d(&[&vec!(5, 6),], 0, true));
+        println!("{}", a.merge_1d(&[&vec!(5, 6),], 1, false));
+        println!("{}", a.merge_1d(&[&vec!(5, 6),], 1, true));        
+    }
+
+    #[test]
+    fn test_take() {  
+        let a = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6]]);
+        let b = DenseMatrix::from_2d_array(&[&[1, 2], &[3, 4], &[5, 6]]);        
+
+        println!("{}", a);  
+        println!("{}", a.take(&[0, 2], 1));   
+        println!("{}", b);  
+        println!("{}", b.take(&[0, 2], 0));        
+    }
+
+    #[test]
+    fn test_mut() {  
+        let mut a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);        
+        a.abs();
+        a.neg();
+          
+        println!("{}", a);                   
+    }
+
+    #[test]
+    fn test_reshape() {  
+        let a = DenseMatrix::from_2d_array(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9], &[10, 11, 12]]);        
+                
+        println!("{}", a.reshape(2, 6, 0));
+        println!("{}", a.reshape(3, 4, 1));
+    }
+
+    #[test]
+    fn test_eq() {  
+        let a = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.]]);   
+        let b = DenseMatrix::from_2d_array(&[&[1., 2., 3.], &[4., 5., 6.], &[7., 8., 9.]]);   
+        let c = DenseMatrix::from_2d_array(&[&[1. + f32::EPSILON, 2., 3.], &[4., 5., 6. + f32::EPSILON]]);
+        let d = DenseMatrix::from_2d_array(&[&[1. + 0.5, 2., 3.], &[4., 5., 6. + f32::EPSILON]]);
+                
+        assert!(!relative_eq!(a, b));
+        assert!(!relative_eq!(a, d));
+        assert!(relative_eq!(a, c));
+    }
+}

--- a/src/linalg/dense/mod.rs
+++ b/src/linalg/dense/mod.rs
@@ -1,0 +1,2 @@
+pub mod vector;
+pub mod matrix;

--- a/src/linalg/dense/vector.rs
+++ b/src/linalg/dense/vector.rs
@@ -1,0 +1,320 @@
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use crate::num::{Number, FloatNumber};
+use crate::linalg::base::{Array, MutArray, ArrayView1, MutArrayView1, Array1};
+
+#[derive(Debug)]
+pub struct VecMutView<'a, T: Debug + Display + Copy + Sized> {
+    ptr: &'a mut [T]
+}
+
+#[derive(Debug, Clone)]
+pub struct VecView<'a, T: Debug + Display + Copy + Sized> {
+    ptr: &'a [T]
+}
+
+impl<T: Debug + Display + Copy + Sized> Array<T, usize> for Vec<T> {    
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArray<T, usize> for Vec<T> {    
+
+    fn set(&mut self, i: usize, x: T) {
+        self[i] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized> ArrayView1<T> for Vec<T> {}
+
+impl<T: Debug + Display + Copy + Sized> MutArrayView1<T> for Vec<T> {}
+
+impl<T: Debug + Display + Copy + Sized> Array1<T> for Vec<T> {  
+    
+    fn slice<'a>(&'a self, range: Range<usize>) -> Box<dyn ArrayView1<T> +'a> {
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        let view = VecView{
+            ptr: &self[range]
+        };
+        Box::new(view)
+    } 
+
+    fn slice_mut<'b>(&'b mut self, range: Range<usize>) -> Box<dyn MutArrayView1<T> + 'b>{
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        let view = VecMutView{
+            ptr: &mut self[range]
+        };
+        Box::new(view)
+    }
+
+    fn fill(len: usize, value: T) -> Self {
+        vec![value; len]
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, len: usize) -> Self where Self: Sized, T: 'a {
+        let mut v: Vec<T> = Vec::with_capacity(len);
+        iter.take(len).for_each(|i| v.push(*i));        
+        v
+    }
+
+    fn from_vec_slice(slice: &[T]) -> Self {
+        let mut v: Vec<T> = Vec::with_capacity(slice.len());
+        slice.iter().for_each(|i| v.push(*i));
+        v
+    }
+
+    fn from_slice(slice: &dyn ArrayView1<T>) -> Self {
+        let mut v: Vec<T> = Vec::with_capacity(slice.shape());
+        slice.iterator(0).for_each(|i| v.push(*i));
+        v
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> Array<T, usize> for VecMutView<'a, T> {    
+    
+    fn get(&self, i: usize) -> &T {
+        &self.ptr[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.ptr.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.ptr.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.ptr.iter())
+    }
+        
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArray<T, usize> for VecMutView<'a, T> {    
+
+    fn set(&mut self, i: usize, x: T) {
+        self.ptr[i] = x;
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.ptr.iter_mut())
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for VecMutView<'a, T> {}
+impl<'a, T: Debug + Display + Copy + Sized> MutArrayView1<T> for VecMutView<'a, T> {}
+
+impl<'a, T: Debug + Display + Copy + Sized> Array<T, usize> for VecView<'a, T> {    
+    
+    fn get(&self, i: usize) -> &T {
+        &self.ptr[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.ptr.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.ptr.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.ptr.iter())
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for VecView<'a, T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dot_product<T: Number, V: Array1<T>>(v: &V) -> T {
+        let vv = V::zeros(10);
+        let v_s = vv.slice(0..3);
+        let dot = v_s.dot(v);
+        dot
+    }
+
+    fn vector_ops<T: FloatNumber, V: Array1<T>>(_: &V) -> T {
+        let v = V::zeros(10);
+        v.max()
+    }
+
+    #[test]
+    fn test_get_set() {
+        let mut x = vec![1, 2, 3];
+        assert_eq!(3, *x.get(2));
+        x.set(1, 1);
+        assert_eq!(1, *x.get(1));        
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_set() {        
+        vec![1, 2, 3].set(3, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_get() {        
+        vec![1, 2, 3].get(3);
+    }
+
+    #[test]    
+    fn test_len() {
+        let x = vec![1, 2, 3];
+        assert_eq!(3, x.len());
+    }
+
+    #[test]    
+    fn test_is_empty() {        
+        assert!(vec![1; 0].is_empty());
+        assert!(!vec![1, 2, 3].is_empty());
+    }
+
+    #[test]    
+    fn test_iterator() { 
+        let v: Vec<i32> =  vec![1, 2, 3].iterator(0).map(|&v| v * 2).collect();
+        assert_eq!(vec![2, 4, 6], v);
+    }
+
+    #[test] 
+    #[should_panic]   
+    fn test_failed_iterator() { 
+        let _ = vec![1, 2, 3].iterator(1);        
+    }
+
+    #[test]    
+    fn test_mut_iterator() { 
+        let mut x = vec![1, 2, 3];
+        x.iterator_mut(0).for_each(|v| *v = *v * 2);
+        assert_eq!(vec![2, 4, 6], x);
+    }
+
+    #[test] 
+    #[should_panic]   
+    fn test_failed_mut_iterator() { 
+        let _ = vec![1, 2, 3].iterator_mut(1);        
+    }
+
+    #[test]
+    fn test_slice() {   
+        let x = vec![1, 2, 3, 4, 5];
+        let x_slice = x.slice(2..3);    
+        assert_eq!(1, x_slice.shape());
+        assert_eq!(3, *x_slice.get(0));            
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_slice() {   
+        vec![1, 2, 3].slice(0..4);        
+    }
+
+    #[test]
+    fn test_mut_slice() {   
+        let mut x = vec![1, 2, 3, 4, 5];
+        let mut x_slice = x.slice_mut(2..4);   
+        x_slice.set(0, 9);
+        assert_eq!(2, x_slice.shape());
+        assert_eq!(9, *x_slice.get(0));
+        assert_eq!(4, *x_slice.get(1));            
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_failed_mut_slice() {   
+        vec![1, 2, 3].slice_mut(0..4);        
+    }
+
+    #[test]
+    fn test_init() {            
+        assert_eq!(Vec::fill(3, 0), vec![0, 0, 0]);        
+        assert_eq!(Vec::from_iterator([0, 1, 2, 3].iter(), 3), vec![0, 1, 2]);        
+        assert_eq!(Vec::from_vec_slice(&[0, 1, 2]), vec![0, 1, 2]); 
+        assert_eq!(Vec::from_vec_slice(&[0, 1, 2, 3, 4][2..]), vec![2, 3, 4]); 
+        assert_eq!(Vec::from_slice(&vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]); 
+        assert_eq!(Vec::from_slice(vec![1, 2, 3, 4, 5].slice(0..3).as_ref()), vec![1, 2, 3]);        
+    }
+
+    #[test]
+    fn test_mul_scalar() {
+        let mut x = vec![1., 2., 3.];    
+
+        let mut y = Vec::<f32>::zeros(10);
+
+        y.slice_mut(0..2).add_scalar_mut(1.0);
+        y.sub_scalar(1.0);
+        x.slice_mut(0..2).sub_scalar_mut(2.);
+        
+        println!("Value: {:?}", x);
+
+    }
+
+    #[test]
+    fn test_dot() {        
+        let y_i = vec![1, 2, 3];
+        let y = vec![1.0, 2.0, 3.0];
+        
+        println!("Regular dot1: {:?}", dot_product(&y));        
+
+        let x = vec![4.0, 5.0, 6.0];
+        println!("Regular dot2: {:?}", y.slice(0..3).dot(&(*x.slice(0..3))));
+        println!("Regular dot2: {:?}", y.slice(0..3).dot(&x));
+        println!("Regular dot2: {:?}", y.dot(&x));
+        println!("Regular dot2: {:?}", y_i.dot(&y_i));
+    }    
+
+    #[test]
+    fn test_operators() {
+        let mut x: Vec<f32> = Vec::zeros(10);
+        
+        x.add_scalar(15.0);
+        {
+            let mut x_s = x.slice_mut(0..5);
+            x_s.add_scalar_mut(1.0);
+        }
+
+        println!("Value: {:?}", x.slice(2..3).min());
+
+        println!("{:?}", x);
+    }
+
+    #[test]
+    fn test_vector_ops() {
+        let mut x = vec![1., 2., 3.];
+
+        vector_ops(&x);
+    }
+
+}

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -34,6 +34,12 @@
 //! let u: DenseMatrix<f64> = svd.U;
 //! ```
 
+pub mod base;
+pub mod dense;
+#[cfg(feature = "nalgebra-bindings")]
+pub mod nalgebra;
+#[cfg(feature = "ndarray-bindings")]
+pub mod ndarray;
 pub mod cholesky;
 /// The matrix is represented in terms of its eigenvalues and eigenvectors.
 pub mod evd;

--- a/src/linalg/nalgebra/matrix.rs
+++ b/src/linalg/nalgebra/matrix.rs
@@ -1,0 +1,251 @@
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use crate::linalg::base::{Array, MutArray, ArrayView1, ArrayView2, MutArrayView2, Array2};
+
+use nalgebra::{Matrix, Dynamic, VecStorage, MatrixSlice, MatrixSliceMut, Dim, Scalar};
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array<T, (usize, usize)> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>> {
+
+    fn get(&self, pos: (usize, usize)) -> &T {
+        &self[pos]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        self.shape()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new((0..self.nrows()).flat_map(move |r| (0..self.ncols()).map(move |c| &self[(r, c)]) )),
+            _ => Box::new(self.iter())
+        }        
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArray<T, (usize, usize)> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>> {    
+
+    fn set(&mut self, i: (usize, usize), x: T) {        
+        self[i] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");        
+        let ptr = self.as_mut_ptr(); 
+        let (rstride, cstride) = self.strides();
+        match axis {
+            0 => Box::new((0..self.nrows()).flat_map(move |r| (0..self.ncols()).map(move |c| unsafe { &mut *ptr.add(r * rstride + c * cstride)}))),
+            _ => Box::new(self.iter_mut())
+        }
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> ArrayView2<T> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>> {}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArrayView2<T> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, (usize, usize)> for MatrixSlice<'a, T, Dynamic, Dynamic, RStride, CStride> {
+
+    fn get(&self, pos: (usize, usize)) -> &T {
+        &self[pos]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new((0..self.nrows()).flat_map(move |r| (0..self.ncols()).map(move |c| &self[(r, c)]) )),
+            _ => Box::new(self.iter())
+        }
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView2<T> for MatrixSlice<'a, T, Dynamic, Dynamic, RStride, CStride> {    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, (usize, usize)> for MatrixSliceMut<'a, T, Dynamic, Dynamic, RStride, CStride> {    
+
+    fn get(&self, pos: (usize, usize)) -> &T {        
+        &self[pos]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new(self.iter()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| &self[(r, c)]) ))
+        }
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArray<T, (usize, usize)> for MatrixSliceMut<'a, T, Dynamic, Dynamic, RStride, CStride> {    
+
+    fn set(&mut self, pos: (usize, usize), x: T){
+        self[(pos.0, pos.1)] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b>{
+        let ptr = self.as_mut_ptr();                        
+        let (rstride, cstride) = self.strides();        
+        match axis {
+            0 => Box::new((0..self.nrows()).flat_map(move |r| (0..self.ncols()).map(move |c| unsafe { &mut *ptr.add(r * rstride + c * cstride)}))),
+            _ => Box::new(self.iter_mut())
+        }
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArrayView2<T> for MatrixSliceMut<'a, T, Dynamic, Dynamic, RStride, CStride> {       
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView2<T> for MatrixSliceMut<'a, T, Dynamic, Dynamic, RStride, CStride> {       
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array2<T> for Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>> {     
+    
+    fn get_row<'a>(&'a self, row: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(self.row_part(row, self.ncols()))
+    }
+
+    fn get_col<'a>(&'a self, col: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(self.column_part(col, self.nrows()))
+    }
+
+    fn slice<'a>(&'a self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn ArrayView2<T> + 'a> {
+        Box::new(self.slice_range(rows, cols))
+    }
+
+    fn slice_mut<'a>(&'a mut self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn MutArrayView2<T> + 'a> where Self: Sized {
+        Box::new(self.slice_range_mut(rows, cols))
+    }
+
+    fn fill(nrows: usize, ncols: usize, value: T) -> Self {        
+        Self::from_element(nrows, ncols, value)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, nrows: usize, ncols: usize, axis: u8) -> Self where T: 'a {                
+        match axis {
+            0 => {   
+                unsafe {             
+                    let mut m = Self::new_uninitialized_generic(Dynamic::new(nrows), Dynamic::new(ncols));
+                    (0..nrows).flat_map(move |r| (0..ncols).map(move |c| (r, c))).zip(iter).for_each(|((r, c), v)| m[(r, c)] = *v);
+                    m
+                }                
+            },
+            _ => Self::from_iterator(nrows, ncols, iter.take(nrows * ncols).map(|&v| v))
+        }
+    }    
+
+    fn transpose(&self) -> Self {
+        self.transpose()
+    }
+    
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, Matrix2x3, RowDVector};
+
+    #[test]
+    fn test_get_set() {
+        let mut a = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]);
+        
+        assert_eq!(*Array::get(&a, (1, 1)), 5);
+        a.set((1, 1), 9);
+        assert_eq!(a, DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 9, 6]));        
+    }
+
+    #[test]
+    fn test_my_iterator() {
+        let a = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]);        
+        
+        let v: Vec<i32> =  a.iterator(0).map(|&v| v).collect();
+        assert_eq!(v, vec!(1, 2, 3, 4, 5, 6));        
+    }
+
+    #[test]
+    fn test_mut_iterator() {
+        let mut a = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]);                   
+        
+        a.iterator_mut(0).enumerate().for_each(|(i, v)| *v = i);        
+        assert_eq!(a, DMatrix::from_row_slice(2, 3, &[0, 1, 2, 3, 4, 5]));        
+        a.iterator_mut(1).enumerate().for_each(|(i, v)| *v = i);        
+        assert_eq!(a, DMatrix::from_row_slice(2, 3, &[0, 2, 4, 1, 3, 5]));        
+    }
+
+    #[test]
+    fn test_slice() {   
+        let x = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]); 
+        let x_slice = Array2::slice(&x, 0..2, 1..2);    
+        assert_eq!((2, 1), x_slice.shape());        
+        assert_eq!(x_slice.iterator(0).map(|&v| v).collect::<Vec<i32>>(), [2, 5]);        
+    }
+
+    #[test]
+    fn test_slice_iter() {   
+        let x = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]);  
+        let x_slice = Array2::slice(&x, 0..2, 0..3);            
+        assert_eq!(x_slice.iterator(0).map(|&v| v).collect::<Vec<i32>>(), vec![1, 2, 3, 4, 5, 6]);        
+        assert_eq!(x_slice.iterator(1).map(|&v| v).collect::<Vec<i32>>(), vec![1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn test_slice_mut_iter() {   
+        let mut x = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]); 
+        {
+            let mut x_slice = Array2::slice_mut(&mut x, 0..2, 0..3);
+            x_slice.iterator_mut(0).enumerate().for_each(|(i, v)| *v = i);
+        }        
+        assert_eq!(x, DMatrix::from_row_slice(2, 3, &[0, 1, 2, 3, 4, 5]));
+        {
+            let mut x_slice = Array2::slice_mut(&mut x, 0..2, 0..3);
+            x_slice.iterator_mut(1).enumerate().for_each(|(i, v)| *v = i);
+        }        
+        assert_eq!(x, DMatrix::from_row_slice(2, 3, &[0, 2, 4, 1, 3, 5]));        
+    }
+
+    #[test]
+    fn test_c_from_iterator() {
+        let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let a: DMatrix<i32> = Array2::from_iterator(data.iter(), 4, 3, 0);
+        println!("{}", a);
+        let a: DMatrix<i32> = Array2::from_iterator(data.iter(), 4, 3, 1);
+        println!("{}", a);
+    }
+
+    #[test]
+    fn test_matmul() {        
+        let a = DMatrix::from_row_slice(2, 3, &[1, 2, 3, 4, 5, 6]); 
+        let b = DMatrix::from_row_slice(3, 2, &[1, 2, 3, 4, 5, 6]);              
+        println!("{}", a.matmul(&b));
+    }
+    
+}

--- a/src/linalg/nalgebra/mod.rs
+++ b/src/linalg/nalgebra/mod.rs
@@ -1,0 +1,2 @@
+pub mod vector;
+pub mod matrix;

--- a/src/linalg/nalgebra/vector.rs
+++ b/src/linalg/nalgebra/vector.rs
@@ -1,0 +1,340 @@
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use crate::linalg::base::{Array, MutArray, ArrayView1, MutArrayView1, Array1};
+
+use nalgebra::{Matrix, U1, Dynamic, VecStorage, MatrixSlice, MatrixSliceMut, Scalar, Dim};
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array<T, usize> for Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array<T, usize> for Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArray<T, usize> for Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>> {    
+
+    fn set(&mut self, i: usize, x: T) {        
+        self[i] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArray<T, usize> for Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>> {    
+
+    fn set(&mut self, i: usize, x: T) {        
+        self[i] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> ArrayView1<T> for Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>> {}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> ArrayView1<T> for Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>> {}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArrayView1<T> for Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>> {}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> MutArrayView1<T> for Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, usize> for MatrixSlice<'a, T, U1, Dynamic, RStride, CStride> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, usize> for MatrixSlice<'a, T, Dynamic, U1, RStride, CStride> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView1<T> for MatrixSlice<'a, T, U1, Dynamic, RStride, CStride> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView1<T> for MatrixSlice<'a, T, Dynamic, U1, RStride, CStride> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, usize> for MatrixSliceMut<'a, T, U1, Dynamic, RStride, CStride> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> Array<T, usize> for MatrixSliceMut<'a, T, Dynamic, U1, RStride, CStride> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArray<T, usize> for MatrixSliceMut<'a, T, U1, Dynamic, RStride, CStride> {    
+
+    fn set(&mut self, i: usize, x: T) {
+        self[i] = x;
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArray<T, usize> for MatrixSliceMut<'a, T, Dynamic, U1, RStride, CStride> {    
+
+    fn set(&mut self, i: usize, x: T) {
+        self[i] = x;
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView1<T> for MatrixSliceMut<'a, T, U1, Dynamic, RStride, CStride> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> ArrayView1<T> for MatrixSliceMut<'a, T, Dynamic, U1, RStride, CStride> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArrayView1<T> for MatrixSliceMut<'a, T, U1, Dynamic, RStride, CStride> {}
+
+impl<'a, T: Debug + Display + Copy + Sized + Scalar, RStride: Dim, CStride: Dim> MutArrayView1<T> for MatrixSliceMut<'a, T, Dynamic, U1, RStride, CStride> {}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array1<T> for Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>> {  
+
+    fn slice<'a>(&'a self, range: Range<usize>) -> Box<dyn ArrayView1<T> +'a> {
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.columns_range(range))        
+    } 
+
+    fn slice_mut<'b>(&'b mut self, range: Range<usize>) -> Box<dyn MutArrayView1<T> + 'b>{
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.columns_range_mut(range))        
+    }
+
+    fn fill(len: usize, value: T) -> Self {
+        Self::from_element(len, value)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, len: usize) -> Self where Self: Sized, T: 'a {                
+        Self::from_iterator(len, iter.map(|&v| v))
+    }
+
+    fn from_vec_slice(slice: &[T]) -> Self {        
+        Self::from_row_slice(slice)
+    }
+
+    fn from_slice(slice: &dyn ArrayView1<T>) -> Self {
+        Self::from_iterator(slice.shape(), slice.iterator(0).map(|&v| v))
+    }
+
+}
+
+impl<T: Debug + Display + Copy + Sized + Scalar> Array1<T> for Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>> {  
+
+    fn slice<'a>(&'a self, range: Range<usize>) -> Box<dyn ArrayView1<T> +'a> {
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.rows_range(range))        
+    } 
+
+    fn slice_mut<'b>(&'b mut self, range: Range<usize>) -> Box<dyn MutArrayView1<T> + 'b>{
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.rows_range_mut(range))        
+    }
+
+    fn fill(len: usize, value: T) -> Self {
+        Self::from_element(len, value)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, len: usize) -> Self where Self: Sized, T: 'a {                
+        Self::from_iterator(len, iter.map(|&v| v))
+    }
+
+    fn from_vec_slice(slice: &[T]) -> Self {        
+        Self::from_row_slice(slice)
+    }
+
+    fn from_slice(slice: &dyn ArrayView1<T>) -> Self {
+        Self::from_iterator(slice.shape(), slice.iterator(0).map(|&v| v))
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;    
+    use nalgebra::{RowDVector};
+
+    #[test]
+    fn test_get_set() {
+        let mut a = RowDVector::from_vec(vec![1, 2, 3]);        
+        
+        assert_eq!(*Array::get(&a, 1), 2);
+        a.set(1, 9);
+        assert_eq!(a, RowDVector::from_vec(vec![1, 9, 3]));        
+    }
+
+    #[test]
+    fn test_iterator() {
+        let a = RowDVector::from_vec(vec![1, 2, 3]);        
+        
+        let v: Vec<i32> =  a.iterator(0).map(|&v| v).collect();
+        assert_eq!(v, vec!(1, 2, 3));        
+    }
+
+    #[test]
+    fn test_mut_iterator() {
+        let mut a = RowDVector::from_vec(vec![1, 2, 3]);
+        
+        a.iterator_mut(0).for_each(|v| *v = 1);
+        assert_eq!(a, RowDVector::from_vec(vec![1, 1, 1]));        
+    }
+
+    #[test]
+    fn test_slice() {   
+        let x = RowDVector::from_vec(vec![1, 2, 3, 4, 5]);        
+        let x_slice = Array1::slice(&x, 2..3);    
+        assert_eq!(1, x_slice.shape());
+        assert_eq!(3, *x_slice.get(0));            
+    }
+
+    #[test]
+    fn test_mut_slice() {   
+        let mut x = RowDVector::from_vec(vec![1, 2, 3, 4, 5]);
+        let mut x_slice = Array1::slice_mut(&mut x, 2..4);   
+        x_slice.set(0, 9);
+        assert_eq!(2, x_slice.shape());
+        assert_eq!(9, *x_slice.get(0));
+        assert_eq!(4, *x_slice.get(1));            
+    }
+
+    #[test]
+    fn test_fill() {   
+        let x: RowDVector<i32> = Array1::fill(3, 1);
+        assert_eq!(x, RowDVector::from_vec(vec![1, 1, 1]));            
+    }
+
+    #[test]
+    fn test_from_iterator() {   
+        let x: RowDVector<i32> = Array1::from_iterator(vec![1, 2, 3].iter(), 3);
+        assert_eq!(x, RowDVector::from_vec(vec![1, 2, 3]));            
+    }
+
+    #[test]
+    fn test_from_vec_slice() {   
+        let x: RowDVector<i32> = Array1::from_vec_slice(&vec![1, 2, 3]);
+        assert_eq!(x, RowDVector::from_vec(vec![1, 2, 3]));            
+    }
+
+    #[test]
+    fn test_from_slice() {   
+        let x = RowDVector::from_vec(vec![1, 2, 3, 4, 5]);
+        let y: RowDVector<i32> = Array1::from_slice(Array1::slice(&x, 1..4).as_ref());
+        assert_eq!(y, RowDVector::from_vec(vec![2, 3, 4]));            
+    }
+
+}
+

--- a/src/linalg/ndarray/matrix.rs
+++ b/src/linalg/ndarray/matrix.rs
@@ -1,0 +1,244 @@
+use std::fmt;
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use crate::linalg::base::{Array as BaseArray, MutArray, ArrayView1, ArrayView2, MutArrayView2, Array1, Array2};
+
+use ndarray::ScalarOperand;
+use ndarray::{concatenate, s, Array, ArrayBase, Axis, Ix1, Ix2, ArrayView, ArrayViewMut, OwnedRepr};
+
+impl<T: Debug + Display + Copy + Sized> BaseArray<T, (usize, usize)> for ArrayBase<OwnedRepr<T>, Ix2> {
+
+    fn get(&self, pos: (usize, usize)) -> &T {
+        &self[[pos.0, pos.1]]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new(self.iter()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| &self[[r, c]]) ))
+        }
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArray<T, (usize, usize)> for ArrayBase<OwnedRepr<T>, Ix2> {    
+
+    fn set(&mut self, pos: (usize, usize), x: T) {        
+        self[[pos.0, pos.1]] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        let ptr = self.as_mut_ptr();                
+        let stride = self.strides();
+        let (rstride, cstride) = (stride[0] as usize, stride[1] as usize);        
+        match axis {
+            0 => Box::new(self.iter_mut()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| unsafe { &mut *ptr.add(r * rstride + c * cstride)})))
+        }
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized> ArrayView2<T> for ArrayBase<OwnedRepr<T>, Ix2> {    
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArrayView2<T> for ArrayBase<OwnedRepr<T>, Ix2> {            
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> BaseArray<T, (usize, usize)> for ArrayView<'a, T, Ix2> {
+
+    fn get(&self, pos: (usize, usize)) -> &T {
+        &self[[pos.0, pos.1]]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new(self.iter()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| &self[[r, c]]) ))
+        }
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized> Array2<T> for ArrayBase<OwnedRepr<T>, Ix2> {     
+    
+    fn get_row<'a>(&'a self, row: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(self.row(row))
+    }
+
+    fn get_col<'a>(&'a self, col: usize) -> Box<dyn ArrayView1<T> + 'a> {
+        Box::new(self.column(col))
+    }
+
+    fn slice<'a>(&'a self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn ArrayView2<T> + 'a> {
+        Box::new(self.slice(s![rows, cols]))
+    }
+
+    fn slice_mut<'a>(&'a mut self, rows: Range<usize>, cols: Range<usize>) -> Box<dyn MutArrayView2<T> + 'a> where Self: Sized {
+        Box::new(self.slice_mut(s![rows, cols]))
+    }
+
+    fn fill(nrows: usize, ncols: usize, value: T) -> Self {        
+        Array::from_elem([nrows, ncols], value)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, nrows: usize, ncols: usize, axis: u8) -> Self where T: 'a {        
+        let a = Array::from_iter(iter.take(nrows * ncols).map(|&v| v)).into_shape((nrows, ncols)).unwrap();
+        match axis {
+            0 => a,
+            _ => a.reversed_axes().into_shape((nrows, ncols)).unwrap()
+        }
+    }    
+
+    fn transpose(&self) -> Self {
+        self.t().to_owned()
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView2<T> for ArrayView<'a, T, Ix2> {    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> BaseArray<T, (usize, usize)> for ArrayViewMut<'a, T, Ix2> {    
+
+    fn get(&self, pos: (usize, usize)) -> &T {        
+        &self[[pos.0, pos.1]]
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 1 || axis == 0, "For two dimensional array `axis` should be either 0 or 1");
+        match axis {
+            0 => Box::new(self.iter()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| &self[[r, c]]) ))
+        }
+    }
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArray<T, (usize, usize)> for ArrayViewMut<'a, T, Ix2> {    
+
+    fn set(&mut self, pos: (usize, usize), x: T){
+        self[[pos.0, pos.1]] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b>{
+        let ptr = self.as_mut_ptr();                
+        let stride = self.strides();
+        let (rstride, cstride) = (stride[0] as usize, stride[1] as usize);        
+        match axis {
+            0 => Box::new(self.iter_mut()),
+            _ => Box::new((0..self.ncols()).flat_map(move |c| (0..self.nrows()).map(move |r| unsafe { &mut *ptr.add(r * rstride + c * cstride)})))
+        }
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArrayView2<T> for ArrayViewMut<'a, T, Ix2> {       
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView2<T> for ArrayViewMut<'a, T, Ix2> {       
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{arr2, Array2 as NDArray2};
+
+    #[test]
+    fn test_get_set() {
+        let mut a = arr2(&[[1, 2, 3], [4, 5, 6]]);        
+        
+        assert_eq!(*BaseArray::get(&a, (1, 1)), 5);
+        a.set((1, 1), 9);
+        assert_eq!(a, arr2(&[[1, 2, 3], [4, 9, 6]]));        
+    }
+
+    #[test]
+    fn test_iterator() {
+        let a = arr2(&[[1, 2, 3], [4, 5, 6]]);        
+        
+        let v: Vec<i32> =  a.iterator(0).map(|&v| v).collect();
+        assert_eq!(v, vec!(1, 2, 3, 4, 5, 6));        
+    }
+
+    #[test]
+    fn test_mut_iterator() {
+        let mut a = arr2(&[[1, 2, 3], [4, 5, 6]]);                   
+        
+        a.iterator_mut(0).enumerate().for_each(|(i, v)| *v = i);        
+        assert_eq!(a, arr2(&[[0, 1, 2], [3, 4, 5]]));        
+        a.iterator_mut(1).enumerate().for_each(|(i, v)| *v = i);        
+        assert_eq!(a, arr2(&[[0, 2, 4], [1, 3, 5]]));        
+    }
+
+    #[test]
+    fn test_slice() {   
+        let x = arr2(&[[1, 2, 3], [4, 5, 6]]); 
+        let x_slice = Array2::slice(&x, 0..2, 1..2);    
+        assert_eq!((2, 1), x_slice.shape());
+        let v: Vec<i32> = x_slice.iterator(0).map(|&v| v).collect();
+        assert_eq!(v, [2, 5]);        
+    }
+
+    #[test]
+    fn test_slice_iter() {   
+        let x = arr2(&[[1, 2, 3], [4, 5, 6]]); 
+        let x_slice = Array2::slice(&x, 0..2, 0..3);            
+        assert_eq!(x_slice.iterator(0).map(|&v| v).collect::<Vec<i32>>(), vec![1, 2, 3, 4, 5, 6]);        
+        assert_eq!(x_slice.iterator(1).map(|&v| v).collect::<Vec<i32>>(), vec![1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn test_slice_mut_iter() {   
+        let mut x = arr2(&[[1, 2, 3], [4, 5, 6]]); 
+        {
+            let mut x_slice = Array2::slice_mut(&mut x, 0..2, 0..3);
+            x_slice.iterator_mut(0).enumerate().for_each(|(i, v)| *v = i);
+        }        
+        assert_eq!(x, arr2(&[[0, 1, 2], [3, 4, 5]]));
+        {
+            let mut x_slice = Array2::slice_mut(&mut x, 0..2, 0..3);
+            x_slice.iterator_mut(1).enumerate().for_each(|(i, v)| *v = i);
+        }        
+        assert_eq!(x, arr2(&[[0, 2, 4], [1, 3, 5]]));        
+    }
+
+    #[test]
+    fn test_c_from_iterator() {
+        let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let a: NDArray2<i32> = Array2::from_iterator(data.iter(), 4, 3, 0);
+        println!("{}", a);
+        let a: NDArray2<i32> = Array2::from_iterator(data.iter(), 4, 3, 1);
+        println!("{}", a);
+    }
+
+}

--- a/src/linalg/ndarray/mod.rs
+++ b/src/linalg/ndarray/mod.rs
@@ -1,0 +1,2 @@
+pub mod vector;
+pub mod matrix;

--- a/src/linalg/ndarray/vector.rs
+++ b/src/linalg/ndarray/vector.rs
@@ -1,0 +1,184 @@
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+
+use crate::linalg::base::{Array as BaseArray, MutArray, ArrayView1, MutArrayView1, Array1};
+
+use ndarray::{s, Array, ArrayBase, Ix1, OwnedRepr, ArrayView, ArrayViewMut};
+
+impl<T: Debug + Display + Copy + Sized> BaseArray<T, usize> for ArrayBase<OwnedRepr<T>, Ix1> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<T: Debug + Display + Copy + Sized> MutArray<T, usize> for ArrayBase<OwnedRepr<T>, Ix1> {    
+
+    fn set(&mut self, i: usize, x: T) {        
+        self[i] = x
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }    
+
+}
+
+impl<T: Debug + Display + Copy + Sized> ArrayView1<T> for ArrayBase<OwnedRepr<T>, Ix1> {}
+
+impl<T: Debug + Display + Copy + Sized> MutArrayView1<T> for ArrayBase<OwnedRepr<T>, Ix1> {}
+
+impl<'a, T: Debug + Display + Copy + Sized> BaseArray<T, usize> for ArrayView<'a, T, Ix1> {
+
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {        
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    } 
+
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for ArrayView<'a, T, Ix1> {}
+
+impl<'a, T: Debug + Display + Copy + Sized> BaseArray<T, usize> for ArrayViewMut<'a, T, Ix1> {    
+    
+    fn get(&self, i: usize) -> &T {
+        &self[i]
+    }
+
+    fn shape(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool{
+        self.len() > 0
+    }
+
+    fn iterator<'b>(&'b self, axis: u8) -> Box<dyn Iterator<Item = &'b T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter())
+    }
+        
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> MutArray<T, usize> for ArrayViewMut<'a, T, Ix1> {    
+
+    fn set(&mut self, i: usize, x: T) {
+        self[i] = x;
+    }
+
+    fn iterator_mut<'b>(&'b mut self, axis: u8) -> Box<dyn Iterator<Item = &'b mut T> + 'b> {
+        assert!(axis == 0, "For one dimensional array `axis` should == 0");
+        Box::new(self.iter_mut())
+    }
+    
+}
+
+impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for ArrayViewMut<'a, T, Ix1> {}
+impl<'a, T: Debug + Display + Copy + Sized> MutArrayView1<T> for ArrayViewMut<'a, T, Ix1> {}
+
+impl<T: Debug + Display + Copy + Sized> Array1<T> for ArrayBase<OwnedRepr<T>, Ix1> {  
+
+    fn slice<'a>(&'a self, range: Range<usize>) -> Box<dyn ArrayView1<T> +'a> {
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.slice(s![range]))        
+    } 
+
+    fn slice_mut<'b>(&'b mut self, range: Range<usize>) -> Box<dyn MutArrayView1<T> + 'b>{
+        assert!(range.end <= self.len(), "`range` should be <= {}", self.len());
+        Box::new(self.slice_mut(s![range]))  
+    }
+
+    fn fill(len: usize, value: T) -> Self {
+        Array::from_elem(len, value)
+    }
+
+    fn from_iterator<'a, I: Iterator<Item = &'a T>>(iter: I, len: usize) -> Self where Self: Sized, T: 'a {                
+        Array::from_iter(iter.take(len).map(|&v| v))
+    }
+
+    fn from_vec_slice(slice: &[T]) -> Self {        
+        Array::from_iter(slice.iter().map(|&v| v))
+    }
+
+    fn from_slice(slice: &dyn ArrayView1<T>) -> Self {
+        Array::from_iter(slice.iterator(0).map(|&v| v))
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{arr1};
+
+    #[test]
+    fn test_get_set() {
+        let mut a = arr1(&[1, 2, 3]);        
+        
+        assert_eq!(*BaseArray::get(&a, 1), 2);
+        a.set(1, 9);
+        assert_eq!(a, arr1(&[1, 9, 3]));        
+    }
+
+    #[test]
+    fn test_iterator() {
+        let a = arr1(&[1, 2, 3]);        
+        
+        let v: Vec<i32> =  a.iterator(0).map(|&v| v).collect();
+        assert_eq!(v, vec!(1, 2, 3));        
+    }
+
+    #[test]
+    fn test_mut_iterator() {
+        let mut a = arr1(&[1, 2, 3]);        
+        
+        a.iterator_mut(0).for_each(|v| *v = 1);
+        assert_eq!(a, arr1(&[1, 1, 1]));        
+    }
+
+    #[test]
+    fn test_slice() {   
+        let x = arr1(&[1, 2, 3, 4, 5]);
+        let x_slice = Array1::slice(&x, 2..3);    
+        assert_eq!(1, x_slice.shape());
+        assert_eq!(3, *x_slice.get(0));            
+    }
+
+    #[test]
+    fn test_mut_slice() {   
+        let mut x = arr1(&[1, 2, 3, 4, 5]);
+        let mut x_slice = Array1::slice_mut(&mut x, 2..4);   
+        x_slice.set(0, 9);
+        assert_eq!(2, x_slice.shape());
+        assert_eq!(9, *x_slice.get(0));
+        assert_eq!(4, *x_slice.get(1));            
+    }
+
+}

--- a/src/linalg/ndarray_bindings.rs
+++ b/src/linalg/ndarray_bindings.rs
@@ -966,7 +966,7 @@ mod tests {
         let error: f64 = y
             .into_iter()
             .zip(y_hat.into_iter())
-            .map(|(&a, &b)| (a - b).abs())
+            .map(|(a, b)| (a - b).abs())
             .sum();
 
         assert!(error <= 1.0);

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -6,35 +6,36 @@
 //! Example:
 //!
 //! ```
-//! use smartcore::linalg::naive::dense_matrix::*;
+//! use smartcore::linalg::dense::matrix::DenseMatrix;
 //! use smartcore::naive_bayes::categorical::CategoricalNB;
 //!
 //! let x = DenseMatrix::from_2d_array(&[
-//!              &[3., 4., 0., 1.],
-//!              &[3., 0., 0., 1.],
-//!              &[4., 4., 1., 2.],
-//!              &[4., 2., 4., 3.],
-//!              &[4., 2., 4., 2.],
-//!              &[4., 1., 1., 0.],
-//!              &[1., 1., 1., 1.],
-//!              &[0., 4., 1., 0.],
-//!              &[0., 3., 2., 1.],
-//!              &[0., 3., 1., 1.],
-//!              &[3., 4., 0., 1.],
-//!              &[3., 4., 2., 4.],
-//!              &[0., 3., 1., 2.],
-//!              &[0., 4., 1., 2.],
+//!              &[3, 4, 0, 1],
+//!              &[3, 0, 0, 1],
+//!              &[4, 4, 1, 2],
+//!              &[4, 2, 4, 3],
+//!              &[4, 2, 4, 2],
+//!              &[4, 1, 1, 0],
+//!              &[1, 1, 1, 1],
+//!              &[0, 4, 1, 0],
+//!              &[0, 3, 2, 1],
+//!              &[0, 3, 1, 1],
+//!              &[3, 4, 0, 1],
+//!              &[3, 4, 2, 4],
+//!              &[0, 3, 1, 2],
+//!              &[0, 4, 1, 2],
 //!          ]);
-//! let y = vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 1., 1., 1., 0.];
+//! let y: Vec<u32> = vec![0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0];
 //!
 //! let nb = CategoricalNB::fit(&x, &y, Default::default()).unwrap();
 //! let y_hat = nb.predict(&x).unwrap();
 //! ```
+use num_traits::Unsigned;
+
 use crate::api::{Predictor, SupervisedEstimator};
 use crate::error::Failed;
-use crate::linalg::BaseVector;
-use crate::linalg::Matrix;
-use crate::math::num::RealNumber;
+use crate::linalg::base::{Array2, Array1, ArrayView1};
+use crate::num::Number;
 use crate::naive_bayes::{BaseNaiveBayes, NBDistribution};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -42,14 +43,14 @@ use serde::{Deserialize, Serialize};
 /// Naive Bayes classifier for categorical features
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
-struct CategoricalNBDistribution<T: RealNumber> {
+struct CategoricalNBDistribution<T: Number + Unsigned> {
     /// number of training samples observed in each class
     class_count: Vec<usize>,
     /// class labels known to the classifier
     class_labels: Vec<T>,
     /// probability of each class
-    class_priors: Vec<T>,
-    coefficients: Vec<Vec<Vec<T>>>,
+    class_priors: Vec<f64>,
+    coefficients: Vec<Vec<Vec<f64>>>,
     /// Number of features of each sample
     n_features: usize,
     /// Number of categories for each feature
@@ -60,7 +61,7 @@ struct CategoricalNBDistribution<T: RealNumber> {
     category_count: Vec<Vec<Vec<usize>>>,
 }
 
-impl<T: RealNumber> PartialEq for CategoricalNBDistribution<T> {
+impl<T: Number + Unsigned> PartialEq for CategoricalNBDistribution<T> {
     fn eq(&self, other: &Self) -> bool {
         if self.class_labels == other.class_labels
             && self.class_priors == other.class_priors
@@ -80,7 +81,7 @@ impl<T: RealNumber> PartialEq for CategoricalNBDistribution<T> {
                         return false;
                     }
                     for (a_i_j, b_i_j) in a_i.iter().zip(b_i.iter()) {
-                        if (*a_i_j - *b_i_j).abs() > T::epsilon() {
+                        if (*a_i_j - *b_i_j).abs() > std::f64::EPSILON {
                             return false;
                         }
                     }
@@ -93,29 +94,29 @@ impl<T: RealNumber> PartialEq for CategoricalNBDistribution<T> {
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for CategoricalNBDistribution<T> {
-    fn prior(&self, class_index: usize) -> T {
+impl<T: Number + Unsigned> NBDistribution<T, T> for CategoricalNBDistribution<T> {
+    fn prior(&self, class_index: usize) -> f64 {
         if class_index >= self.class_labels.len() {
-            T::zero()
+            0f64
         } else {
             self.class_priors[class_index]
         }
     }
 
-    fn log_likelihood(&self, class_index: usize, j: &M::RowVector) -> T {
+    fn log_likelihood<'a>(&'a self, class_index: usize, j: &'a Box<dyn ArrayView1<T> + 'a>) -> f64 {
         if class_index < self.class_labels.len() {
-            let mut likelihood = T::zero();
-            for feature in 0..j.len() {
-                let value = j.get(feature).floor().to_usize().unwrap();
+            let mut likelihood = 0f64;
+            for feature in 0..j.shape() {
+                let value = j.get(feature).to_usize().unwrap();
                 if self.coefficients[feature][class_index].len() > value {
                     likelihood += self.coefficients[feature][class_index][value];
                 } else {
-                    return T::zero();
+                    return 0f64;
                 }
             }
             likelihood
         } else {
-            T::zero()
+            0f64
         }
     }
 
@@ -124,13 +125,13 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for CategoricalNBDistribu
     }
 }
 
-impl<T: RealNumber> CategoricalNBDistribution<T> {
+impl<T: Number + Unsigned> CategoricalNBDistribution<T> {
     /// Fits the distribution to a NxM matrix where N is number of samples and M is number of features.
     /// * `x` - training data.
     /// * `y` - vector with target values (classes) of length N.
     /// * `alpha` - Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
-    pub fn fit<M: Matrix<T>>(x: &M, y: &M::RowVector, alpha: T) -> Result<Self, Failed> {
-        if alpha < T::zero() {
+    pub fn fit<X: Array2<T>, Y: Array1<T>>(x: &X, y: &Y, alpha: f64) -> Result<Self, Failed> {
+        if alpha < 0f64 {
             return Err(Failed::fit(&format!(
                 "alpha should be >= 0, alpha=[{}]",
                 alpha
@@ -138,7 +139,7 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
         }
 
         let (n_samples, n_features) = x.shape();
-        let y_samples = y.len();
+        let y_samples = y.shape();
         if y_samples != n_samples {
             return Err(Failed::fit(&format!(
                 "Size of x should equal size of y; |x|=[{}], |y|=[{}]",
@@ -152,10 +153,9 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
                 n_samples
             )));
         }
-        let y: Vec<usize> = y
-            .to_vec()
-            .iter()
-            .map(|y_i| y_i.floor().to_usize().unwrap())
+        let y: Vec<usize> = y            
+            .iterator(0)
+            .map(|y_i| y_i.to_usize().unwrap())
             .collect();
 
         let y_max = y
@@ -164,7 +164,7 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
             .ok_or_else(|| Failed::fit(&"Failed to get the labels of y.".to_string()))?;
 
         let class_labels: Vec<T> = (0..*y_max + 1)
-            .map(|label| T::from(label).unwrap())
+            .map(|label| T::from_usize(label).unwrap())
             .collect();
         let mut class_count = vec![0_usize; class_labels.len()];
         for elem in y.iter() {
@@ -174,9 +174,9 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
         let mut n_categories: Vec<usize> = Vec::with_capacity(n_features);
         for feature in 0..n_features {
             let feature_max = x
-                .get_col_as_vec(feature)
-                .iter()
-                .map(|f_i| f_i.floor().to_usize().unwrap())
+                .get_col(feature)
+                .iterator(0)
+                .map(|f_i| f_i.to_usize().unwrap())
                 .max()
                 .ok_or_else(|| {
                     Failed::fit(&format!(
@@ -187,34 +187,33 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
             n_categories.push(feature_max + 1);
         }
 
-        let mut coefficients: Vec<Vec<Vec<T>>> = Vec::with_capacity(class_labels.len());
+        let mut coefficients: Vec<Vec<Vec<f64>>> = Vec::with_capacity(class_labels.len());
         let mut category_count: Vec<Vec<Vec<usize>>> = Vec::with_capacity(class_labels.len());
         for (feature_index, &n_categories_i) in n_categories.iter().enumerate().take(n_features) {
-            let mut coef_i: Vec<Vec<T>> = Vec::with_capacity(n_features);
+            let mut coef_i: Vec<Vec<f64>> = Vec::with_capacity(n_features);
             let mut category_count_i: Vec<Vec<usize>> = Vec::with_capacity(n_features);
             for (label, &label_count) in class_labels.iter().zip(class_count.iter()) {
                 let col = x
-                    .get_col_as_vec(feature_index)
-                    .iter()
+                    .get_col(feature_index)
+                    .iterator(0)
                     .enumerate()
-                    .filter(|(i, _j)| T::from(y[*i]).unwrap() == *label)
+                    .filter(|(i, _j)| T::from_usize(y[*i]).unwrap() == *label)
                     .map(|(_, j)| *j)
                     .collect::<Vec<T>>();
                 let mut feat_count: Vec<usize> = vec![0_usize; n_categories_i];
                 for row in col.iter() {
-                    let index = row.floor().to_usize().unwrap();
+                    let index = row.to_usize().unwrap();
                     feat_count[index] += 1;
                 }
 
                 let coef_i_j = feat_count
                     .iter()
-                    .map(|c| {
-                        ((T::from(*c).unwrap() + alpha)
-                            / (T::from(label_count).unwrap()
-                                + T::from(n_categories_i).unwrap() * alpha))
+                    .map(|&c| {
+                        ((c as f64 + alpha)
+                            / (label_count as f64 + n_categories_i as f64 * alpha))
                             .ln()
                     })
-                    .collect::<Vec<T>>();
+                    .collect::<Vec<f64>>();
                 category_count_i.push(feat_count);
                 coef_i.push(coef_i_j);
             }
@@ -224,8 +223,8 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
 
         let class_priors = class_count
             .iter()
-            .map(|&count| T::from(count).unwrap() / T::from(n_samples).unwrap())
-            .collect::<Vec<T>>();
+            .map(|&count| count as f64 / n_samples as f64)
+            .collect::<Vec<f64>>();
 
         Ok(Self {
             class_count,
@@ -242,60 +241,60 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
 /// `CategoricalNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
-pub struct CategoricalNBParameters<T: RealNumber> {
+pub struct CategoricalNBParameters {
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
-    pub alpha: T,
+    pub alpha: f64,
 }
 
-impl<T: RealNumber> CategoricalNBParameters<T> {
+impl CategoricalNBParameters {
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
-    pub fn with_alpha(mut self, alpha: T) -> Self {
+    pub fn with_alpha(mut self, alpha: f64) -> Self {
         self.alpha = alpha;
         self
     }
 }
 
-impl<T: RealNumber> Default for CategoricalNBParameters<T> {
+impl Default for CategoricalNBParameters {
     fn default() -> Self {
-        Self { alpha: T::one() }
+        Self { alpha: 1f64 }
     }
 }
 
 /// CategoricalNB implements the categorical naive Bayes algorithm for categorically distributed data.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
-pub struct CategoricalNB<T: RealNumber, M: Matrix<T>> {
-    inner: BaseNaiveBayes<T, M, CategoricalNBDistribution<T>>,
+pub struct CategoricalNB<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> {
+    inner: BaseNaiveBayes<T, T, X, Y, CategoricalNBDistribution<T>>,
 }
 
-impl<T: RealNumber, M: Matrix<T>> SupervisedEstimator<M, M::RowVector, CategoricalNBParameters<T>>
-    for CategoricalNB<T, M>
+impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> SupervisedEstimator<X, Y, CategoricalNBParameters>
+    for CategoricalNB<T, X, Y>
 {
     fn fit(
-        x: &M,
-        y: &M::RowVector,
-        parameters: CategoricalNBParameters<T>,
+        x: &X,
+        y: &Y,
+        parameters: CategoricalNBParameters,
     ) -> Result<Self, Failed> {
         CategoricalNB::fit(x, y, parameters)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for CategoricalNB<T, M> {
-    fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
+impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> Predictor<X, Y> for CategoricalNB<T, X, Y> {
+    fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.predict(x)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> CategoricalNB<T, M> {
+impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
     /// Fits CategoricalNB with given data
     /// * `x` - training data of size NxM where N is the number of samples and M is the number of
     /// features.
     /// * `y` - vector with target values (classes) of length N.
     /// * `parameters` - additional parameters like alpha for smoothing
     pub fn fit(
-        x: &M,
-        y: &M::RowVector,
-        parameters: CategoricalNBParameters<T>,
+        x: &X,
+        y: &Y,
+        parameters: CategoricalNBParameters,
     ) -> Result<Self, Failed> {
         let alpha = parameters.alpha;
         let distribution = CategoricalNBDistribution::fit(x, y, alpha)?;
@@ -306,7 +305,7 @@ impl<T: RealNumber, M: Matrix<T>> CategoricalNB<T, M> {
     /// Estimates the class labels for the provided data.
     /// * `x` - data of shape NxM where N is number of data points to estimate and M is number of features.
     /// Returns a vector of size N with class estimates.
-    pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
+    pub fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.inner.predict(x)
     }
 
@@ -341,41 +340,41 @@ impl<T: RealNumber, M: Matrix<T>> CategoricalNB<T, M> {
     /// Holds arrays of shape (n_classes, n_categories of respective feature)
     /// for each feature. Each array provides the empirical log probability
     /// of categories given the respective feature and class, ``P(x_i|y)``.
-    pub fn feature_log_prob(&self) -> &Vec<Vec<Vec<T>>> {
+    pub fn feature_log_prob(&self) -> &Vec<Vec<Vec<f64>>> {
         &self.inner.distribution.coefficients
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::linalg::naive::dense_matrix::DenseMatrix;
+    use super::*;    
+    use crate::linalg::dense::matrix::DenseMatrix;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_categorical_naive_bayes() {
-        let x = DenseMatrix::from_2d_array(&[
-            &[0., 2., 1., 0.],
-            &[0., 2., 1., 1.],
-            &[1., 2., 1., 0.],
-            &[2., 1., 1., 0.],
-            &[2., 0., 0., 0.],
-            &[2., 0., 0., 1.],
-            &[1., 0., 0., 1.],
-            &[0., 1., 1., 0.],
-            &[0., 0., 0., 0.],
-            &[2., 1., 0., 0.],
-            &[0., 1., 0., 1.],
-            &[1., 1., 1., 1.],
-            &[1., 2., 0., 0.],
-            &[2., 1., 1., 1.],
+        let x = DenseMatrix::<u32>::from_2d_array(&[
+            &[0, 2, 1, 0],
+            &[0, 2, 1, 1],
+            &[1, 2, 1, 0],
+            &[2, 1, 1, 0],
+            &[2, 0, 0, 0],
+            &[2, 0, 0, 1],
+            &[1, 0, 0, 1],
+            &[0, 1, 1, 0],
+            &[0, 0, 0, 0],
+            &[2, 1, 0, 0],
+            &[0, 1, 0, 1],
+            &[1, 1, 1, 1],
+            &[1, 2, 0, 0],
+            &[2, 1, 1, 1],
         ]);
-        let y = vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 1., 1., 1., 0.];
+        let y: Vec<u32> = vec![0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0];
 
         let cnb = CategoricalNB::fit(&x, &y, Default::default()).unwrap();
 
         // checking parity with scikit
-        assert_eq!(cnb.classes(), &[0., 1.]);
+        assert_eq!(cnb.classes(), &[0, 1]);
         assert_eq!(cnb.class_count(), &[5, 9]);
         assert_eq!(cnb.n_features(), 4);
         assert_eq!(cnb.n_categories(), &[3, 3, 2, 2]);
@@ -427,37 +426,37 @@ mod tests {
             ]
         );
 
-        let x_test = DenseMatrix::from_2d_array(&[&[0., 2., 1., 0.], &[2., 2., 0., 0.]]);
+        let x_test = DenseMatrix::from_2d_array(&[&[0, 2, 1, 0], &[2, 2, 0, 0]]);
         let y_hat = cnb.predict(&x_test).unwrap();
-        assert_eq!(y_hat, vec![0., 1.]);
+        assert_eq!(y_hat, vec![0, 1]);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_categorical_naive_bayes2() {
-        let x = DenseMatrix::from_2d_array(&[
-            &[3., 4., 0., 1.],
-            &[3., 0., 0., 1.],
-            &[4., 4., 1., 2.],
-            &[4., 2., 4., 3.],
-            &[4., 2., 4., 2.],
-            &[4., 1., 1., 0.],
-            &[1., 1., 1., 1.],
-            &[0., 4., 1., 0.],
-            &[0., 3., 2., 1.],
-            &[0., 3., 1., 1.],
-            &[3., 4., 0., 1.],
-            &[3., 4., 2., 4.],
-            &[0., 3., 1., 2.],
-            &[0., 4., 1., 2.],
+        let x = DenseMatrix::<u32>::from_2d_array(&[
+            &[3, 4, 0, 1],
+            &[3, 0, 0, 1],
+            &[4, 4, 1, 2],
+            &[4, 2, 4, 3],
+            &[4, 2, 4, 2],
+            &[4, 1, 1, 0],
+            &[1, 1, 1, 1],
+            &[0, 4, 1, 0],
+            &[0, 3, 2, 1],
+            &[0, 3, 1, 1],
+            &[3, 4, 0, 1],
+            &[3, 4, 2, 4],
+            &[0, 3, 1, 2],
+            &[0, 4, 1, 2],
         ]);
-        let y = vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 1., 1., 1., 0.];
+        let y: Vec<u32> = vec![0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0];
 
         let cnb = CategoricalNB::fit(&x, &y, Default::default()).unwrap();
         let y_hat = cnb.predict(&x).unwrap();
         assert_eq!(
             y_hat,
-            vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 0., 1., 1., 1.]
+            vec![0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1]
         );
     }
 
@@ -465,27 +464,27 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {
-        let x = DenseMatrix::<f64>::from_2d_array(&[
-            &[3., 4., 0., 1.],
-            &[3., 0., 0., 1.],
-            &[4., 4., 1., 2.],
-            &[4., 2., 4., 3.],
-            &[4., 2., 4., 2.],
-            &[4., 1., 1., 0.],
-            &[1., 1., 1., 1.],
-            &[0., 4., 1., 0.],
-            &[0., 3., 2., 1.],
-            &[0., 3., 1., 1.],
-            &[3., 4., 0., 1.],
-            &[3., 4., 2., 4.],
-            &[0., 3., 1., 2.],
-            &[0., 4., 1., 2.],
+        let x = DenseMatrix::from_2d_array(&[
+            &[3, 4, 0, 1],
+            &[3, 0, 0, 1],
+            &[4, 4, 1, 2],
+            &[4, 2, 4, 3],
+            &[4, 2, 4, 2],
+            &[4, 1, 1, 0],
+            &[1, 1, 1, 1],
+            &[0, 4, 1, 0],
+            &[0, 3, 2, 1],
+            &[0, 3, 1, 1],
+            &[3, 4, 0, 1],
+            &[3, 4, 2, 4],
+            &[0, 3, 1, 2],
+            &[0, 4, 1, 2],
         ]);
 
-        let y = vec![0., 0., 1., 1., 1., 0., 1., 0., 1., 1., 1., 1., 1., 0.];
+        let y: Vec<u32> = vec![0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0];
         let cnb = CategoricalNB::fit(&x, &y, Default::default()).unwrap();
 
-        let deserialized_cnb: CategoricalNB<f64, DenseMatrix<f64>> =
+        let deserialized_cnb: CategoricalNB<u32, DenseMatrix<u32>, Vec<u32>> =
             serde_json::from_str(&serde_json::to_string(&cnb).unwrap()).unwrap();
 
         assert_eq!(cnb, deserialized_cnb);

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -6,7 +6,7 @@
 //! Example:
 //!
 //! ```
-//! use smartcore::linalg::naive::dense_matrix::*;
+//! use smartcore::linalg::dense::matrix::DenseMatrix;
 //! use smartcore::naive_bayes::gaussian::GaussianNB;
 //!
 //! let x = DenseMatrix::from_2d_array(&[
@@ -17,18 +17,18 @@
 //!              &[ 2.,  1.],
 //!              &[ 3.,  2.],
 //!          ]);
-//! let y = vec![1., 1., 1., 2., 2., 2.];
+//! let y: Vec<u32> = vec![1, 1, 1, 2, 2, 2];
 //!
 //! let nb = GaussianNB::fit(&x, &y, Default::default()).unwrap();
 //! let y_hat = nb.predict(&x).unwrap();
 //! ```
+use std::hash::Hash;
+use num_traits::Unsigned;
+
 use crate::api::{Predictor, SupervisedEstimator};
 use crate::error::Failed;
-use crate::linalg::row_iter;
-use crate::linalg::BaseVector;
-use crate::linalg::Matrix;
-use crate::math::num::RealNumber;
-use crate::math::vector::RealNumberVector;
+use crate::linalg::base::{Array2, Array1, ArrayView1};
+use crate::num::Number;
 use crate::naive_bayes::{BaseNaiveBayes, NBDistribution};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -36,32 +36,32 @@ use serde::{Deserialize, Serialize};
 /// Naive Bayes classifier for categorical features
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
-struct GaussianNBDistribution<T: RealNumber> {
+struct GaussianNBDistribution<T: Number> {
     /// class labels known to the classifier
     class_labels: Vec<T>,
     /// number of training samples observed in each class
     class_count: Vec<usize>,
     /// probability of each class.
-    class_priors: Vec<T>,
+    class_priors: Vec<f64>,
     /// variance of each feature per class
-    var: Vec<Vec<T>>,
+    var: Vec<Vec<f64>>,
     /// mean of each feature per class
-    theta: Vec<Vec<T>>,
+    theta: Vec<Vec<f64>>,
 }
 
-impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for GaussianNBDistribution<T> {
-    fn prior(&self, class_index: usize) -> T {
+impl<X: Number, Y: Number + Ord + Eq + Unsigned + Hash> NBDistribution<X, Y> for GaussianNBDistribution<Y> {
+    fn prior(&self, class_index: usize) -> f64 {
         if class_index >= self.class_labels.len() {
-            T::zero()
+            0f64
         } else {
             self.class_priors[class_index]
         }
     }
 
-    fn log_likelihood(&self, class_index: usize, j: &M::RowVector) -> T {
-        let mut likelihood = T::zero();
-        for feature in 0..j.len() {
-            let value = j.get(feature);
+    fn log_likelihood<'a>(&self, class_index: usize, j: &'a Box<dyn ArrayView1<X> + 'a>) -> f64 {
+        let mut likelihood = 0f64;
+        for feature in 0..j.shape() {
+            let value = X::to_f64(j.get(feature)).unwrap();
             let mean = self.theta[class_index][feature];
             let variance = self.var[class_index][feature];
             likelihood += self.calculate_log_probability(value, mean, variance);
@@ -69,7 +69,7 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for GaussianNBDistributio
         likelihood
     }
 
-    fn classes(&self) -> &Vec<T> {
+    fn classes(&self) -> &Vec<Y> {
         &self.class_labels
     }
 }
@@ -77,32 +77,32 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for GaussianNBDistributio
 /// `GaussianNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone)]
-pub struct GaussianNBParameters<T: RealNumber> {
+pub struct GaussianNBParameters {
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
-    pub priors: Option<Vec<T>>,
+    pub priors: Option<Vec<f64>>,
 }
 
-impl<T: RealNumber> GaussianNBParameters<T> {
+impl GaussianNBParameters {
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
-    pub fn with_priors(mut self, priors: Vec<T>) -> Self {
+    pub fn with_priors(mut self, priors: Vec<f64>) -> Self {
         self.priors = Some(priors);
         self
     }
 }
 
-impl<T: RealNumber> GaussianNBDistribution<T> {
+impl<TY: Number + Ord + Eq + Unsigned + Hash> GaussianNBDistribution<TY> {
     /// Fits the distribution to a NxM matrix where N is number of samples and M is number of features.
     /// * `x` - training data.
     /// * `y` - vector with target values (classes) of length N.
     /// * `priors` - Optional vector with prior probabilities of the classes. If not defined,
     /// priors are adjusted according to the data.
-    pub fn fit<M: Matrix<T>>(
-        x: &M,
-        y: &M::RowVector,
-        priors: Option<Vec<T>>,
+    pub fn fit<TX: Number, X: Array2<TX>, Y: Array1<TY>>(
+        x: &X,
+        y: &Y,
+        priors: Option<Vec<f64>>,
     ) -> Result<Self, Failed> {
         let (n_samples, n_features) = x.shape();
-        let y_samples = y.len();
+        let y_samples = y.shape();
         if y_samples != n_samples {
             return Err(Failed::fit(&format!(
                 "Size of x should equal size of y; |x|=[{}], |y|=[{}]",
@@ -115,15 +115,14 @@ impl<T: RealNumber> GaussianNBDistribution<T> {
                 "Size of x and y should greater than 0; |x|=[{}]",
                 n_samples
             )));
-        }
-        let y = y.to_vec();
-        let (class_labels, indices) = <Vec<T> as RealNumberVector<T>>::unique_with_indices(&y);
+        }        
+        let (class_labels, indices) = y.unique_with_indices();
 
         let mut class_count = vec![0_usize; class_labels.len()];
 
-        let mut subdataset: Vec<Vec<Vec<T>>> = vec![vec![]; class_labels.len()];
+        let mut subdataset: Vec<Vec<Box<dyn ArrayView1<TX>>>> = (0..class_labels.len()).map(|_| vec![]).collect();
 
-        for (row, class_index) in row_iter(x).zip(indices.iter()) {
+        for (row, class_index) in x.row_iter().zip(indices.iter()) {
             class_count[*class_index] += 1;
             subdataset[*class_index].push(row);
         }
@@ -138,24 +137,19 @@ impl<T: RealNumber> GaussianNBDistribution<T> {
         } else {
             class_count
                 .iter()
-                .map(|&c| T::from(c).unwrap() / T::from(n_samples).unwrap())
+                .map(|&c| c as f64 / n_samples as f64)
                 .collect()
         };
 
-        let subdataset: Vec<M> = subdataset
-            .into_iter()
-            .map(|v| {
-                let mut m = M::zeros(v.len(), n_features);
-                for (row_i, v_i) in v.iter().enumerate() {
-                    for (col_j, v_i_j) in v_i.iter().enumerate().take(n_features) {
-                        m.set(row_i, col_j, *v_i_j);
-                    }
-                }
-                m
-            })
-            .collect();
+        let subdataset: Vec<X> = subdataset
+            .iter()
+            .map(|v| {                
+                X::cancatenate_1d(&v, 0)
+            }).collect();
 
-        let (var, theta): (Vec<Vec<T>>, Vec<Vec<T>>) = subdataset
+        println!("{:?}", subdataset);
+
+        let (var, theta): (Vec<Vec<f64>>, Vec<Vec<f64>>) = subdataset
             .iter()
             .map(|data| (data.var(0), data.mean(0)))
             .unzip();
@@ -171,45 +165,45 @@ impl<T: RealNumber> GaussianNBDistribution<T> {
 
     /// Calculate probability of x equals to a value of a Gaussian distribution given its mean and its
     /// variance.
-    fn calculate_log_probability(&self, value: T, mean: T, variance: T) -> T {
-        let pi = T::from(std::f64::consts::PI).unwrap();
-        -((value - mean).powf(T::two()) / (T::two() * variance))
-            - (T::two() * pi).ln() / T::two()
-            - (variance).ln() / T::two()
+    fn calculate_log_probability(&self, value: f64, mean: f64, variance: f64) -> f64 {
+        let pi = std::f64::consts::PI;
+        -((value - mean).powf(2.0) / (2.0 * variance))
+            - (2.0 * pi).ln() / 2.0
+            - (variance).ln() / 2.0
     }
 }
 
 /// GaussianNB implements the categorical naive Bayes algorithm for categorically distributed data.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
-pub struct GaussianNB<T: RealNumber, M: Matrix<T>> {
-    inner: BaseNaiveBayes<T, M, GaussianNBDistribution<T>>,
+pub struct GaussianNB<TX: Number, TY: Number + Ord + Eq + Unsigned + Hash, X: Array2<TX>, Y: Array1<TY>> {
+    inner: BaseNaiveBayes<TX, TY, X, Y, GaussianNBDistribution<TY>>,
 }
 
-impl<T: RealNumber, M: Matrix<T>> SupervisedEstimator<M, M::RowVector, GaussianNBParameters<T>>
-    for GaussianNB<T, M>
+impl<TX: Number, TY: Number + Ord + Eq + Unsigned + Hash, X: Array2<TX>, Y: Array1<TY>> SupervisedEstimator<X, Y, GaussianNBParameters>
+    for GaussianNB<TX, TY, X, Y>
 {
-    fn fit(x: &M, y: &M::RowVector, parameters: GaussianNBParameters<T>) -> Result<Self, Failed> {
+    fn fit(x: &X, y: &Y, parameters: GaussianNBParameters) -> Result<Self, Failed> {
         GaussianNB::fit(x, y, parameters)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for GaussianNB<T, M> {
-    fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
+impl<TX: Number, TY: Number + Ord + Eq + Unsigned + Hash, X: Array2<TX>, Y: Array1<TY>> Predictor<X, Y> for GaussianNB<TX, TY, X, Y> {
+    fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.predict(x)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> GaussianNB<T, M> {
+impl<TX: Number, TY: Number + Ord + Eq + Unsigned + Hash, X: Array2<TX>, Y: Array1<TY>> GaussianNB<TX, TY, X, Y> {
     /// Fits GaussianNB with given data
     /// * `x` - training data of size NxM where N is the number of samples and M is the number of
     /// features.
     /// * `y` - vector with target values (classes) of length N.
     /// * `parameters` - additional parameters like class priors.
     pub fn fit(
-        x: &M,
-        y: &M::RowVector,
-        parameters: GaussianNBParameters<T>,
+        x: &X,
+        y: &Y,
+        parameters: GaussianNBParameters,
     ) -> Result<Self, Failed> {
         let distribution = GaussianNBDistribution::fit(x, y, parameters.priors)?;
         let inner = BaseNaiveBayes::fit(distribution)?;
@@ -219,13 +213,13 @@ impl<T: RealNumber, M: Matrix<T>> GaussianNB<T, M> {
     /// Estimates the class labels for the provided data.
     /// * `x` - data of shape NxM where N is number of data points to estimate and M is number of features.
     /// Returns a vector of size N with class estimates.
-    pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
+    pub fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.inner.predict(x)
     }
 
     /// Class labels known to the classifier.
     /// Returns a vector of size n_classes.
-    pub fn classes(&self) -> &Vec<T> {
+    pub fn classes(&self) -> &Vec<TY> {
         &self.inner.distribution.class_labels
     }
 
@@ -237,19 +231,19 @@ impl<T: RealNumber, M: Matrix<T>> GaussianNB<T, M> {
 
     /// Probability of each class
     /// Returns a vector of size n_classes.
-    pub fn class_priors(&self) -> &Vec<T> {
+    pub fn class_priors(&self) -> &Vec<f64> {
         &self.inner.distribution.class_priors
     }
 
     /// Mean of each feature per class
     /// Returns a 2d vector of shape (n_classes, n_features).
-    pub fn theta(&self) -> &Vec<Vec<T>> {
+    pub fn theta(&self) -> &Vec<Vec<f64>> {
         &self.inner.distribution.theta
     }
 
     /// Variance of each feature per class
     /// Returns a 2d vector of shape (n_classes, n_features).
-    pub fn var(&self) -> &Vec<Vec<T>> {
+    pub fn var(&self) -> &Vec<Vec<f64>> {
         &self.inner.distribution.var
     }
 }
@@ -257,26 +251,26 @@ impl<T: RealNumber, M: Matrix<T>> GaussianNB<T, M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::linalg::naive::dense_matrix::DenseMatrix;
+    use crate::linalg::dense::matrix::DenseMatrix;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn run_gaussian_naive_bayes() {
         let x = DenseMatrix::from_2d_array(&[
-            &[-1., -1.],
-            &[-2., -1.],
-            &[-3., -2.],
-            &[1., 1.],
-            &[2., 1.],
-            &[3., 2.],
+            &[-1, -1],
+            &[-2, -1],
+            &[-3, -2],
+            &[1, 1],
+            &[2, 1],
+            &[3, 2],
         ]);
-        let y = vec![1., 1., 1., 2., 2., 2.];
+        let y: Vec<u32> = vec![1, 1, 1, 2, 2, 2];
 
         let gnb = GaussianNB::fit(&x, &y, Default::default()).unwrap();
         let y_hat = gnb.predict(&x).unwrap();
         assert_eq!(y_hat, y);
 
-        assert_eq!(gnb.classes(), &[1., 2.]);
+        assert_eq!(gnb.classes(), &[1, 2]);
 
         assert_eq!(gnb.class_count(), &[3, 3]);
 
@@ -307,7 +301,7 @@ mod tests {
             &[2., 1.],
             &[3., 2.],
         ]);
-        let y = vec![1., 1., 1., 2., 2., 2.];
+        let y: Vec<u32> = vec![1, 1, 1, 2, 2, 2];
 
         let priors = vec![0.3, 0.7];
         let parameters = GaussianNBParameters::default().with_priors(priors.clone());
@@ -328,10 +322,10 @@ mod tests {
             &[2., 1.],
             &[3., 2.],
         ]);
-        let y = vec![1., 1., 1., 2., 2., 2.];
+        let y: Vec<u32> = vec![1, 1, 1, 2, 2, 2];
 
         let gnb = GaussianNB::fit(&x, &y, Default::default()).unwrap();
-        let deserialized_gnb: GaussianNB<f64, DenseMatrix<f64>> =
+        let deserialized_gnb: GaussianNB<f64, u32, DenseMatrix<f64>, Vec<u32>> =
             serde_json::from_str(&serde_json::to_string(&gnb).unwrap()).unwrap();
 
         assert_eq!(gnb, deserialized_gnb);

--- a/src/naive_bayes/mod.rs
+++ b/src/naive_bayes/mod.rs
@@ -36,49 +36,52 @@
 //! <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 //! <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 use crate::error::Failed;
-use crate::linalg::BaseVector;
-use crate::linalg::Matrix;
-use crate::math::num::RealNumber;
+use crate::linalg::base::{Array2, Array1, ArrayView1};
+use crate::num::Number;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 /// Distribution used in the Naive Bayes classifier.
-pub(crate) trait NBDistribution<T: RealNumber, M: Matrix<T>> {
+pub(crate) trait NBDistribution<X: Number, Y: Number> {
     /// Prior of class at the given index.
-    fn prior(&self, class_index: usize) -> T;
+    fn prior(&self, class_index: usize) -> f64;
 
     /// Logarithm of conditional probability of sample j given class in the specified index.
-    fn log_likelihood(&self, class_index: usize, j: &M::RowVector) -> T;
+    fn log_likelihood<'a>(&'a self, class_index: usize, j: &'a Box<dyn ArrayView1<X> + 'a>) -> f64;
 
     /// Possible classes of the distribution.
-    fn classes(&self) -> &Vec<T>;
+    fn classes(&self) -> &Vec<Y>;
 }
 
 /// Base struct for the Naive Bayes classifier.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
-pub(crate) struct BaseNaiveBayes<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> {
+pub(crate) struct BaseNaiveBayes<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: NBDistribution<TX, TY>> {
     distribution: D,
-    _phantom_t: PhantomData<T>,
-    _phantom_m: PhantomData<M>,
+    _phantom_tx: PhantomData<TX>,
+    _phantom_ty: PhantomData<TY>,
+    _phantom_x: PhantomData<X>,
+    _phantom_y: PhantomData<Y>
 }
 
-impl<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> BaseNaiveBayes<T, M, D> {
+impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: NBDistribution<TX, TY>> BaseNaiveBayes<TX, TY, X, Y, D> {
     /// Fits NB classifier to a given NBdistribution.
     /// * `distribution` - NBDistribution of the training data
     pub fn fit(distribution: D) -> Result<Self, Failed> {
         Ok(Self {
             distribution,
-            _phantom_t: PhantomData,
-            _phantom_m: PhantomData,
+            _phantom_tx: PhantomData,
+            _phantom_ty: PhantomData,
+            _phantom_x: PhantomData,
+            _phantom_y: PhantomData,
         })
     }
 
     /// Estimates the class labels for the provided data.
     /// * `x` - data of shape NxM where N is number of data points to estimate and M is number of features.
     /// Returns a vector of size N with class estimates.
-    pub fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
+    pub fn predict(&self, x: &X) -> Result<Y, Failed> {
         let y_classes = self.distribution.classes();
         let (rows, _) = x.shape();
         let predictions = (0..rows)
@@ -87,7 +90,7 @@ impl<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> BaseNaiveBayes<T, M, 
                 let (prediction, _probability) = y_classes
                     .iter()
                     .enumerate()
-                    .map(|(class_index, class)| {
+                    .map(|(class_index, class)| {                        
                         (
                             class,
                             self.distribution.log_likelihood(class_index, &row)
@@ -98,8 +101,8 @@ impl<T: RealNumber, M: Matrix<T>, D: NBDistribution<T, M>> BaseNaiveBayes<T, M, 
                     .unwrap();
                 *prediction
             })
-            .collect::<Vec<T>>();
-        let y_hat = M::RowVector::from_array(&predictions);
+            .collect::<Vec<TY>>();
+        let y_hat = Y::from_vec_slice(&predictions);
         Ok(y_hat)
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,0 +1,163 @@
+//! # Real Number
+//! Most algorithms in SmartCore rely on basic linear algebra operations like dot product, matrix decomposition and other subroutines that are defined for a set of real numbers, ℝ.
+//! This module defines real number and some useful functions that are used in [Linear Algebra](../../linalg/index.html) module.
+
+use num_traits::{Num, Float, FromPrimitive, ToPrimitive, Bounded};
+use rand::prelude::*;
+use std::fmt::{Debug, Display};
+use std::iter::{Product, Sum};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+
+pub trait Number:
+    Num
+    + FromPrimitive
+    + ToPrimitive
+    + Debug
+    + Display
+    + Copy
+    + Sum
+    + Product
+    + AddAssign
+    + SubAssign
+    + MulAssign
+    + DivAssign
+    + Bounded
+{}
+
+/// Defines real number
+/// <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_CHTML"></script>
+pub trait FloatNumber:
+    Number + Float
+{
+    /// Copy sign from `sign` - another real number
+    fn copysign(self, sign: Self) -> Self;
+
+    /// Calculates natural \\( \ln(1+e^x) \\) without overflow.
+    fn ln_1pe(self) -> Self;
+
+    /// Efficient implementation of Sigmoid function, \\( S(x) = \frac{1}{1 + e^{-x}} \\), see [Sigmoid function](https://en.wikipedia.org/wiki/Sigmoid_function)
+    fn sigmoid(self) -> Self;
+
+    /// Returns pseudorandom number between 0 and 1
+    fn rand() -> Self;
+
+    /// Returns 2
+    fn two() -> Self;
+
+    /// Returns .5
+    fn half() -> Self;
+
+    /// Returns \\( x^2 \\)
+    fn square(self) -> Self {
+        self * self
+    }
+
+    /// Raw transmutation to u64
+    fn to_f32_bits(self) -> u32;
+}
+
+impl Number for f64 {}
+impl Number for f32 {}
+impl Number for i8 {}
+impl Number for i16 {}
+impl Number for i32 {}
+impl Number for i64 {}
+impl Number for u8 {}
+impl Number for u16 {}
+impl Number for u32 {}
+impl Number for u64 {}
+impl Number for usize {}
+
+impl FloatNumber for f64 {
+    fn copysign(self, sign: Self) -> Self {
+        self.copysign(sign)
+    }
+
+    fn ln_1pe(self) -> f64 {
+        if self > 15. {
+            self
+        } else {
+            self.exp().ln_1p()
+        }
+    }
+
+    fn sigmoid(self) -> f64 {
+        if self < -40. {
+            0.
+        } else if self > 40. {
+            1.
+        } else {
+            1. / (1. + f64::exp(-self))
+        }
+    }
+
+    fn rand() -> f64 {
+        let mut rng = rand::thread_rng();
+        rng.gen()
+    }
+
+    fn two() -> Self {
+        2f64
+    }
+
+    fn half() -> Self {
+        0.5f64
+    }
+
+    fn to_f32_bits(self) -> u32 {
+        self.to_bits() as u32
+    }
+}
+
+impl FloatNumber for f32 {
+    fn copysign(self, sign: Self) -> Self {
+        self.copysign(sign)
+    }
+
+    fn ln_1pe(self) -> f32 {
+        if self > 15. {
+            self
+        } else {
+            self.exp().ln_1p()
+        }
+    }
+
+    fn sigmoid(self) -> f32 {
+        if self < -40. {
+            0.
+        } else if self > 40. {
+            1.
+        } else {
+            1. / (1. + f32::exp(-self))
+        }
+    }
+
+    fn rand() -> f32 {
+        let mut rng = rand::thread_rng();
+        rng.gen()
+    }
+
+    fn two() -> Self {
+        2f32
+    }
+
+    fn half() -> Self {
+        0.5f32
+    }
+
+    fn to_f32_bits(self) -> u32 {
+        self.to_bits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigmoid() {
+        assert_eq!(1.0.sigmoid(), 0.7310585786300049);
+        assert_eq!(41.0.sigmoid(), 1.);
+        assert_eq!((-41.0).sigmoid(), 0.);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+pub mod vec_utils {
+    
+    use crate::num::FloatNumber;
+
+    pub fn approx_eq<T: FloatNumber>(a: &[T], b: &[T], tol: T) -> bool {
+        a.iter().zip(b.iter()).all(|(&a, &b)| (a - b).abs() < tol)
+    }
+}


### PR DESCRIPTION
This PR will eventually solve #85. The goal is to have an abstract layer that can be implemented by concrete library that enables all traditional functionality provided by n-dimensional arrays: array manipulation, transformation, basic linear algebra routines, views e.t.c. 

The abstract layer I am proposing here enables us to:
* have arrays that can hold multiple types, including strings
* implement more efficient ML algorithms that minimize memory copy operations
* have ML algorithms that declare more granular requirements to input and output types, e.g. we can declare an input type for an algorithm that does need a simple non-mutable array w/o typical linear algebra routines. 

As a bonus, this PR introduces a row-major dense matrix that might get handy in some cases. 