### PR TITLE
Fix issue with cover tree k-nearest neighbors

### DIFF
--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -179,7 +179,8 @@ impl<T: Debug + PartialEq, F: RealNumber, D: Distance<T, F>> CoverTree<T, F, D> 
                 }
             }
         }
-
+        
+        neighbors.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
         Ok(neighbors.into_iter().take(k).collect())
     }
 

--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -180,7 +180,9 @@ impl<T: Debug + PartialEq, F: RealNumber, D: Distance<T, F>> CoverTree<T, F, D> 
             }
         }
         
-        neighbors.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        if neighbors.len() > k {
+            neighbors.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        }
         Ok(neighbors.into_iter().take(k).collect())
     }
 


### PR DESCRIPTION
Thank you for all the work you have done on this! My friend and I have been trying to use smartcore's k-nearest neighbors algorithm as part of a dynamic label propagation implementation and we believe we have discovered an issue. The original cover tree version of the k-nearest neighbors algorithm might not work for cases where there are multiple points equidistant from the input point. For example, the current test passes for the given parameters (input point  = 5, k = 3), but fails if k is increased to 4. This is because there are 5 points in the dataset within a radius of 2.0 from 5 (3, 4, 5, 6, 7) and the algorithm does not sort them by distance from the input point before taking the first 4 points from the `neighbors` vector. This has been corrected by sorting the `neighbors` vector before selecting the k points to ensure that they actually are the k-nearest neighbors. There may be a better way to make this fix, but this seems to work. 