### PR TITLE
Added additional doctest and fixed indices

### DIFF
--- a/src/algorithm/neighbour/bbd_tree.rs
+++ b/src/algorithm/neighbour/bbd_tree.rs
@@ -59,7 +59,7 @@ impl<T: RealNumber> BBDTree<T> {
         tree
     }
 
-    pub(in crate) fn clustering(
+    pub(crate) fn clustering(
         &self,
         centroids: &[Vec<T>],
         sums: &mut Vec<Vec<T>>,

--- a/src/linalg/evd.rs
+++ b/src/linalg/evd.rs
@@ -25,6 +25,19 @@
 //! let eigenvectors: DenseMatrix<f64> = evd.V;
 //! let eigenvalues: Vec<f64> = evd.d;
 //! ```
+//! ```
+//! use smartcore::linalg::naive::dense_matrix::*;
+//! use smartcore::linalg::evd::*;
+//!
+//! let A = DenseMatrix::from_2d_array(&[
+//!     &[-5.0, 2.0],
+//!     &[-7.0, 4.0],
+//! ]);
+//!
+//! let evd = A.evd(false).unwrap();
+//! let eigenvectors: DenseMatrix<f64> = evd.V;
+//! let eigenvalues: Vec<f64> = evd.d;
+//! ```
 //!
 //! ## References:
 //! * ["Numerical Recipes: The Art of Scientific Computing",  Press W.H., Teukolsky S.A., Vetterling W.T, Flannery B.P, 3rd ed., Section 11 Eigensystems](http://numerical.recipes/)
@@ -799,10 +812,10 @@ fn sort<T: RealNumber, M: BaseMatrix<T>>(d: &mut [T], e: &mut [T], V: &mut M) {
             }
             i -= 1;
         }
-        d[i as usize + 1] = real;
-        e[i as usize + 1] = img;
+        d[(i + 1) as usize] = real;
+        e[(i + 1) as usize] = img;
         for (k, temp_k) in temp.iter().enumerate().take(n) {
-            V.set(k, i as usize + 1, *temp_k);
+            V.set(k, (i + 1) as usize, *temp_k);
         }
     }
 }

--- a/src/optimization/mod.rs
+++ b/src/optimization/mod.rs
@@ -5,7 +5,7 @@ pub type F<'a, T, X> = dyn for<'b> Fn(&'b X) -> T + 'a;
 pub type DF<'a, X> = dyn for<'b> Fn(&'b mut X, &'b X) + 'a;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FunctionOrder {
     SECOND,
     THIRD,

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -242,7 +242,7 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVR<T, M, K> {
         Ok(y_hat)
     }
 
-    pub(in crate) fn predict_for_row(&self, x: M::RowVector) -> T {
+    pub(crate) fn predict_for_row(&self, x: M::RowVector) -> T {
         let mut f = self.b;
 
         for i in 0..self.instances.len() {

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -285,7 +285,7 @@ impl<'a, T: RealNumber, M: Matrix<T>> NodeVisitor<'a, T, M> {
     }
 }
 
-pub(in crate) fn which_max(x: &[usize]) -> usize {
+pub(crate) fn which_max(x: &[usize]) -> usize {
     let mut m = x[0];
     let mut which = 0;
 
@@ -421,7 +421,7 @@ impl<T: RealNumber> DecisionTreeClassifier<T> {
         Ok(result.to_row_vector())
     }
 
-    pub(in crate) fn predict_for_row<M: Matrix<T>>(&self, x: &M, row: usize) -> usize {
+    pub(crate) fn predict_for_row<M: Matrix<T>>(&self, x: &M, row: usize) -> usize {
         let mut result = 0;
         let mut queue: LinkedList<usize> = LinkedList::new();
 

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -321,7 +321,7 @@ impl<T: RealNumber> DecisionTreeRegressor<T> {
         Ok(result.to_row_vector())
     }
 
-    pub(in crate) fn predict_for_row<M: Matrix<T>>(&self, x: &M, row: usize) -> T {
+    pub(crate) fn predict_for_row<M: Matrix<T>>(&self, x: &M, row: usize) -> T {
         let mut result = T::zero();
         let mut queue: LinkedList<usize> = LinkedList::new();
 


### PR DESCRIPTION
Added an additional doctest to `evd.rs` for a matrix that resulted in failure before these changes. In several locations, changed indices from `i as usize + 1` to `(i+1) as usize` to avoid overflow in type conversion. 

Fixes #140.