### PR TITLE
Handle multiclass precision/recall

### DIFF
--- a/src/math/num.rs
+++ b/src/math/num.rs
@@ -46,8 +46,11 @@ pub trait RealNumber:
         self * self
     }
 
-    /// Raw transmutation to u64
+    /// Raw transmutation to u32
     fn to_f32_bits(self) -> u32;
+
+    /// Raw transmutation to u64
+    fn to_f64_bits(self) -> u64;
 }
 
 impl RealNumber for f64 {
@@ -89,6 +92,10 @@ impl RealNumber for f64 {
     fn to_f32_bits(self) -> u32 {
         self.to_bits() as u32
     }
+
+    fn to_f64_bits(self) -> u64 {
+        self.to_bits()
+    }
 }
 
 impl RealNumber for f32 {
@@ -129,6 +136,10 @@ impl RealNumber for f32 {
 
     fn to_f32_bits(self) -> u32 {
         self.to_bits()
+    }
+
+    fn to_f64_bits(self) -> u64 {
+        self.to_bits() as u64
     }
 }
 

--- a/src/metrics/precision.rs
+++ b/src/metrics/precision.rs
@@ -18,6 +18,8 @@
 //!
 //! <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 //! <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+use std::collections::HashSet;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -42,34 +44,35 @@ impl Precision {
             );
         }
 
+        let mut classes = HashSet::new();
+        for i in 0..y_true.len() {
+            classes.insert(y_true.get(i).to_f32_bits()); 
+        }
+        let classes = classes.len();
+
         let mut tp = 0;
-        let mut p = 0;
-        let n = y_true.len();
-        for i in 0..n {
-            if y_true.get(i) != T::zero() && y_true.get(i) != T::one() {
-                panic!(
-                    "Precision can only be applied to binary classification: {}",
-                    y_true.get(i)
-                );
-            }
-
-            if y_pred.get(i) != T::zero() && y_pred.get(i) != T::one() {
-                panic!(
-                    "Precision can only be applied to binary classification: {}",
-                    y_pred.get(i)
-                );
-            }
-
-            if y_pred.get(i) == T::one() {
-                p += 1;
-
-                if y_true.get(i) == T::one() {
+        let mut fp = 0;
+        for i in 0..y_true.len() {
+            if y_pred.get(i) == y_true.get(i) {
+                if classes == 2 {
+                    if y_true.get(i) == T::one() {
+                        tp += 1;
+                    }
+                } else {
                     tp += 1;
+                }
+            } else {
+                if classes == 2 {
+                    if y_true.get(i) == T::one() {
+                        fp += 1; 
+                    }
+                } else {
+                    fp += 1;
                 }
             }
         }
 
-        T::from_i64(tp).unwrap() / T::from_i64(p).unwrap()
+        T::from_i64(tp).unwrap() / (T::from_i64(tp).unwrap() + T::from_i64(fp).unwrap())
     }
 }
 
@@ -87,6 +90,25 @@ mod tests {
         let score2: f64 = Precision {}.get_score(&y_pred, &y_pred);
 
         assert!((score1 - 0.5).abs() < 1e-8);
+        assert!((score2 - 1.0).abs() < 1e-8);
+
+        let y_pred: Vec<f64> = vec![0., 0., 1., 1., 1., 1.];
+        let y_true: Vec<f64> = vec![0., 1., 1., 0., 1., 0.];
+
+        let score3: f64 = Precision {}.get_score(&y_pred, &y_true);
+        assert!((score3 - 0.5).abs() < 1e-8);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn precision_multiclass() {
+        let y_true: Vec<f64> = vec![0., 0., 0., 1., 1., 1., 2., 2., 2.];
+        let y_pred: Vec<f64> = vec![0., 1., 2., 0., 1., 2., 0., 1., 2.];
+
+        let score1: f64 = Precision {}.get_score(&y_pred, &y_true);
+        let score2: f64 = Precision {}.get_score(&y_pred, &y_pred);
+
+        assert!((score1 - 0.333333333).abs() < 1e-8);
         assert!((score2 - 1.0).abs() < 1e-8);
     }
 }

--- a/src/metrics/precision.rs
+++ b/src/metrics/precision.rs
@@ -46,7 +46,7 @@ impl Precision {
 
         let mut classes = HashSet::new();
         for i in 0..y_true.len() {
-            classes.insert(y_true.get(i).to_f32_bits()); 
+            classes.insert(y_true.get(i).to_f64_bits()); 
         }
         let classes = classes.len();
 

--- a/src/metrics/precision.rs
+++ b/src/metrics/precision.rs
@@ -61,14 +61,12 @@ impl Precision {
                 } else {
                     tp += 1;
                 }
-            } else {
-                if classes == 2 {
-                    if y_true.get(i) == T::one() {
-                        fp += 1;
-                    }
-                } else {
+            } else if classes == 2 {
+                if y_true.get(i) == T::one() {
                     fp += 1;
                 }
+            } else {
+                fp += 1;
             }
         }
 

--- a/src/metrics/precision.rs
+++ b/src/metrics/precision.rs
@@ -46,7 +46,7 @@ impl Precision {
 
         let mut classes = HashSet::new();
         for i in 0..y_true.len() {
-            classes.insert(y_true.get(i).to_f64_bits()); 
+            classes.insert(y_true.get(i).to_f64_bits());
         }
         let classes = classes.len();
 
@@ -64,7 +64,7 @@ impl Precision {
             } else {
                 if classes == 2 {
                     if y_true.get(i) == T::one() {
-                        fp += 1; 
+                        fp += 1;
                     }
                 } else {
                     fp += 1;

--- a/src/metrics/recall.rs
+++ b/src/metrics/recall.rs
@@ -18,6 +18,9 @@
 //!
 //! <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 //! <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+use std::collections::HashSet;
+use std::convert::TryInto;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -42,34 +45,34 @@ impl Recall {
             );
         }
 
+        let mut classes = HashSet::new();
+        for i in 0..y_true.len() {
+            classes.insert(y_true.get(i).to_f64_bits()); 
+        }
+        let classes: i64 = classes.len().try_into().unwrap();
+
         let mut tp = 0;
-        let mut p = 0;
-        let n = y_true.len();
-        for i in 0..n {
-            if y_true.get(i) != T::zero() && y_true.get(i) != T::one() {
-                panic!(
-                    "Recall can only be applied to binary classification: {}",
-                    y_true.get(i)
-                );
-            }
-
-            if y_pred.get(i) != T::zero() && y_pred.get(i) != T::one() {
-                panic!(
-                    "Recall can only be applied to binary classification: {}",
-                    y_pred.get(i)
-                );
-            }
-
-            if y_true.get(i) == T::one() {
-                p += 1;
-
-                if y_pred.get(i) == T::one() {
+        let mut fne = 0;
+        for i in 0..y_true.len() {
+            if y_pred.get(i) == y_true.get(i) {
+                if classes == 2 {
+                    if y_true.get(i) == T::one() {
+                        tp += 1;
+                    }
+                } else {
                     tp += 1;
+                }
+            } else {
+                if classes == 2 {
+                    if y_true.get(i) != T::one() {
+                        fne += 1;
+                    }
+                } else {
+                    fne += 1;
                 }
             }
         }
-
-        T::from_i64(tp).unwrap() / T::from_i64(p).unwrap()
+        T::from_i64(tp).unwrap() / (T::from_i64(tp).unwrap() + T::from_i64(fne).unwrap())
     }
 }
 
@@ -87,6 +90,25 @@ mod tests {
         let score2: f64 = Recall {}.get_score(&y_pred, &y_pred);
 
         assert!((score1 - 0.5).abs() < 1e-8);
+        assert!((score2 - 1.0).abs() < 1e-8);
+
+        let y_pred: Vec<f64> = vec![0., 0., 1., 1., 1., 1.];
+        let y_true: Vec<f64> = vec![0., 1., 1., 0., 1., 0.];
+
+        let score3: f64 = Recall {}.get_score(&y_pred, &y_true);
+        assert!((score3 - 0.66666666).abs() < 1e-8);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn recall_multiclass() {
+        let y_true: Vec<f64> = vec![0., 0., 0., 1., 1., 1., 2., 2., 2.];
+        let y_pred: Vec<f64> = vec![0., 1., 2., 0., 1., 2., 0., 1., 2.];
+
+        let score1: f64 = Recall {}.get_score(&y_pred, &y_true);
+        let score2: f64 = Recall {}.get_score(&y_pred, &y_pred);
+
+        assert!((score1 - 0.333333333).abs() < 1e-8);
         assert!((score2 - 1.0).abs() < 1e-8);
     }
 }

--- a/src/metrics/recall.rs
+++ b/src/metrics/recall.rs
@@ -62,14 +62,12 @@ impl Recall {
                 } else {
                     tp += 1;
                 }
-            } else {
-                if classes == 2 {
-                    if y_true.get(i) != T::one() {
-                        fne += 1;
-                    }
-                } else {
+            } else if classes == 2 {
+                if y_true.get(i) != T::one() {
                     fne += 1;
                 }
+            } else {
+                fne += 1;
             }
         }
         T::from_i64(tp).unwrap() / (T::from_i64(tp).unwrap() + T::from_i64(fne).unwrap())

--- a/src/metrics/recall.rs
+++ b/src/metrics/recall.rs
@@ -47,7 +47,7 @@ impl Recall {
 
         let mut classes = HashSet::new();
         for i in 0..y_true.len() {
-            classes.insert(y_true.get(i).to_f64_bits()); 
+            classes.insert(y_true.get(i).to_f64_bits());
         }
         let classes: i64 = classes.len().try_into().unwrap();
 


### PR DESCRIPTION
This implements `micro` averaging for multiclass precision/recall to handle #151. I believe this is a good default, since it handles imbalanced labels better than `macro` averaging (which is also not yet implemented).

Additionally, the documentation for `to_f32_bits` is incorrect, and that function may currently cause unexpected behavior because it truncates half the bits for f64 values. This breaks things like the uniqueness check I'm doing to count the number of distinct labels. I'd also be open to better methods to count distinct floating point values in Rust, but I haven't seen an easy library function that handles this (with nans etc). I've added `to_f64_bits` to provide the behavior I expected.

