### PR TITLE
feat: allocate first and then proceed to create matrix from Vec of Ro…

### DIFF
--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -343,6 +343,9 @@ pub trait BaseMatrix<T: RealNumber>: Clone + Debug {
     ///    ])
     /// );
     fn from_row_vectors(rows: Vec<Self::RowVector>) -> Option<Self> {
+        if rows.is_empty() {
+            return None;
+        }
         let n = rows.len();
         let m = rows[0].len();
 


### PR DESCRIPTION
…wVectors

I was trying to use this function in a 5000 x 10000 matrix and it took a lot of time and it didn't finish, `v_stack` seems very expensive to be used here.

Not sure if we should return Option<> or an empty matrix when the vec is empty