### PR TITLE
fix: fix compilation warnings when running only with default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["datasets"]
 ndarray-bindings = ["ndarray"]
 nalgebra-bindings = ["nalgebra"]
 datasets = []
-fp_bench = []
+fp_bench = ["itertools"]
 
 [dependencies]
 ndarray = { version = "0.15", optional = true }
@@ -27,7 +27,7 @@ num = "0.4"
 rand = "0.8"
 rand_distr = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
-itertools = "0.10.3"
+itertools = { version = "0.10.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/src/algorithm/neighbour/fastpair.rs
+++ b/src/algorithm/neighbour/fastpair.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-use itertools::Itertools;
 ///
 /// # FastPair: Data-structure for the dynamic closest-pair problem.
 ///
@@ -177,6 +175,7 @@ impl<'a, T: RealNumber, M: Matrix<T>> FastPair<'a, T, M> {
     ///
     #[cfg(feature = "fp_bench")]
     pub fn closest_pair_brute(&self) -> PairwiseDistance<T> {
+	use itertools::Itertools;
         let m = self.samples.shape().0;
 
         let mut closest_pair = PairwiseDistance {

--- a/src/algorithm/neighbour/fastpair.rs
+++ b/src/algorithm/neighbour/fastpair.rs
@@ -175,7 +175,7 @@ impl<'a, T: RealNumber, M: Matrix<T>> FastPair<'a, T, M> {
     ///
     #[cfg(feature = "fp_bench")]
     pub fn closest_pair_brute(&self) -> PairwiseDistance<T> {
-	use itertools::Itertools;
+        use itertools::Itertools;
         let m = self.samples.shape().0;
 
         let mut closest_pair = PairwiseDistance {


### PR DESCRIPTION
I got:
```rust
warning: unused import: `itertools::Itertools`
 --> /Users/morenol/me/smartcore/src/algorithm/neighbour/fastpair.rs:2:5
  |
2 | use itertools::Itertools;
  |     ^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```
which is only used in force-brute implementation