### PR TITLE
Make rand_distr optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["science"]
 default = ["datasets"]
 ndarray-bindings = ["ndarray"]
 nalgebra-bindings = ["nalgebra"]
-datasets = []
+datasets = ["rand_distr"]
 fp_bench = ["itertools"]
 
 [dependencies]
@@ -25,7 +25,7 @@ nalgebra = { version = "0.31", optional = true }
 num-traits = "0.2"
 num = "0.4"
 rand = "0.8"
-rand_distr = "0.4"
+rand_distr = { version = "0.4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 itertools = { version = "0.10.3", optional = true }
 


### PR DESCRIPTION
rand_distr is only used in dataset module

https://github.com/smartcorelib/smartcore/blob/162bed2aa2242e35e02c875821d0d7abaf054070/src/dataset/generator.rs#L5