### PR TITLE
test: provide better output in svm::svc tests

### DIFF
--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -776,8 +776,13 @@ mod tests {
         )
         .and_then(|lr| lr.predict(&x))
         .unwrap();
+        let acc = accuracy(&y_hat, &y);
 
-        assert!(accuracy(&y_hat, &y) >= 0.9);
+        assert!(
+            acc >= 0.9,
+            "accuracy ({}) is not larger or equal to 0.9",
+            acc
+        );
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -860,7 +865,13 @@ mod tests {
         .and_then(|lr| lr.predict(&x))
         .unwrap();
 
-        assert!(accuracy(&y_hat, &y) >= 0.9);
+        let acc = accuracy(&y_hat, &y);
+
+        assert!(
+            acc >= 0.9,
+            "accuracy ({}) is not larger or equal to 0.9",
+            acc
+        );
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]


### PR DESCRIPTION
In test output we are not getting which is the accuracy when it fails. This could help us identify what is going on. I think that it should be related to the fact that these tests depend on `rand` crate usage.

I see that sometimes the accuracy is 1.0, others, 0.95, others 0.9.