### PR TITLE
make default params available to serde

### DIFF
--- a/src/algorithm/neighbour/mod.rs
+++ b/src/algorithm/neighbour/mod.rs
@@ -59,6 +59,12 @@ pub enum KNNAlgorithmName {
     CoverTree,
 }
 
+impl Default for KNNAlgorithmName {
+    fn default() -> Self {
+        KNNAlgorithmName::CoverTree
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub(crate) enum KNNAlgorithm<T: RealNumber, D: Distance<Vec<T>, T>> {

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -65,6 +65,7 @@ pub struct DBSCAN<T: RealNumber, D: Distance<Vec<T>, T>> {
     eps: T,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// DBSCAN clustering algorithm parameters
 pub struct DBSCANParameters<T: RealNumber, D: Distance<Vec<T>, T>> {
@@ -229,7 +230,7 @@ impl<T: RealNumber> Default for DBSCANParameters<T, Euclidian> {
             distance: Distances::euclidian(),
             min_samples: 5,
             eps: T::half(),
-            algorithm: KNNAlgorithmName::CoverTree,
+            algorithm: KNNAlgorithmName::default(),
         }
     }
 }

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -68,14 +68,18 @@ pub struct DBSCAN<T: RealNumber, D: Distance<Vec<T>, T>> {
 #[derive(Debug, Clone)]
 /// DBSCAN clustering algorithm parameters
 pub struct DBSCANParameters<T: RealNumber, D: Distance<Vec<T>, T>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// a function that defines a distance between each pair of point in training data.
     /// This function should extend [`Distance`](../../math/distance/trait.Distance.html) trait.
     /// See [`Distances`](../../math/distance/struct.Distances.html) for a list of available functions.
     pub distance: D,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of samples (or total weight) in a neighborhood for a point to be considered as a core point.
     pub min_samples: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum distance between two samples for one to be considered as in the neighborhood of the other.
     pub eps: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// KNN algorithm to use.
     pub algorithm: KNNAlgorithmName,
 }
@@ -113,14 +117,18 @@ impl<T: RealNumber, D: Distance<Vec<T>, T>> DBSCANParameters<T, D> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct DBSCANSearchParameters<T: RealNumber, D: Distance<Vec<T>, T>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// a function that defines a distance between each pair of point in training data.
     /// This function should extend [`Distance`](../../math/distance/trait.Distance.html) trait.
     /// See [`Distances`](../../math/distance/struct.Distances.html) for a list of available functions.
     pub distance: Vec<D>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of samples (or total weight) in a neighborhood for a point to be considered as a core point.
     pub min_samples: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum distance between two samples for one to be considered as in the neighborhood of the other.
     pub eps: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// KNN algorithm to use.
     pub algorithm: Vec<KNNAlgorithmName>,
 }

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -102,6 +102,7 @@ impl<T: RealNumber> PartialEq for KMeans<T> {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// K-Means clustering algorithm parameters
 pub struct KMeansParameters {

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -145,6 +145,9 @@ pub struct KMeansSearchParameters {
     pub k: Vec<usize>,
     /// Maximum number of iterations of the k-means algorithm for a single run.
     pub max_iter: Vec<usize>,
+    /// Determines random number generation for centroid initialization.
+    /// Use an int to make the randomness deterministic
+    pub seed: Vec<Option<u64>>,
 }
 
 /// KMeans grid search iterator
@@ -152,6 +155,7 @@ pub struct KMeansSearchParametersIterator {
     kmeans_search_parameters: KMeansSearchParameters,
     current_k: usize,
     current_max_iter: usize,
+    current_seed: usize,
 }
 
 impl IntoIterator for KMeansSearchParameters {
@@ -163,6 +167,7 @@ impl IntoIterator for KMeansSearchParameters {
             kmeans_search_parameters: self,
             current_k: 0,
             current_max_iter: 0,
+            current_seed: 0,
         }
     }
 }
@@ -173,6 +178,7 @@ impl Iterator for KMeansSearchParametersIterator {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_k == self.kmeans_search_parameters.k.len()
             && self.current_max_iter == self.kmeans_search_parameters.max_iter.len()
+            && self.current_seed == self.kmeans_search_parameters.seed.len()
         {
             return None;
         }
@@ -180,6 +186,7 @@ impl Iterator for KMeansSearchParametersIterator {
         let next = KMeansParameters {
             k: self.kmeans_search_parameters.k[self.current_k],
             max_iter: self.kmeans_search_parameters.max_iter[self.current_max_iter],
+            seed: self.kmeans_search_parameters.seed[self.current_seed],
         };
 
         if self.current_k + 1 < self.kmeans_search_parameters.k.len() {
@@ -187,9 +194,14 @@ impl Iterator for KMeansSearchParametersIterator {
         } else if self.current_max_iter + 1 < self.kmeans_search_parameters.max_iter.len() {
             self.current_k = 0;
             self.current_max_iter += 1;
+        } else if self.current_seed + 1 < self.kmeans_search_parameters.seed.len() {
+            self.current_k = 0;
+            self.current_max_iter = 0;
+            self.current_seed += 1;
         } else {
             self.current_k += 1;
             self.current_max_iter += 1;
+            self.current_seed += 1;
         }
 
         Some(next)
@@ -203,6 +215,7 @@ impl Default for KMeansSearchParameters {
         KMeansSearchParameters {
             k: vec![default_params.k],
             max_iter: vec![default_params.max_iter],
+            seed: vec![default_params.seed],
         }
     }
 }

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -105,10 +105,13 @@ impl<T: RealNumber> PartialEq for KMeans<T> {
 #[derive(Debug, Clone)]
 /// K-Means clustering algorithm parameters
 pub struct KMeansParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of clusters.
     pub k: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Maximum number of iterations of the k-means algorithm for a single run.
     pub max_iter: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Determines random number generation for centroid initialization.
     /// Use an int to make the randomness deterministic
     pub seed: Option<u64>,
@@ -141,10 +144,13 @@ impl Default for KMeansParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct KMeansSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of clusters.
     pub k: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Maximum number of iterations of the k-means algorithm for a single run.
     pub max_iter: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Determines random number generation for centroid initialization.
     /// Use an int to make the randomness deterministic
     pub seed: Vec<Option<u64>>,

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -83,6 +83,7 @@ impl<T: RealNumber, M: Matrix<T>> PartialEq for PCA<T, M> {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// PCA parameters
 pub struct PCAParameters {

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -86,8 +86,10 @@ impl<T: RealNumber, M: Matrix<T>> PartialEq for PCA<T, M> {
 #[derive(Debug, Clone)]
 /// PCA parameters
 pub struct PCAParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of components to keep.
     pub n_components: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// By default, covariance matrix is used to compute principal components.
     /// Enable this flag if you want to use correlation matrix instead.
     pub use_correlation_matrix: bool,
@@ -120,8 +122,10 @@ impl Default for PCAParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct PCASearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of components to keep.
     pub n_components: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// By default, covariance matrix is used to compute principal components.
     /// Enable this flag if you want to use correlation matrix instead.
     pub use_correlation_matrix: Vec<bool>,

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -72,6 +72,7 @@ impl<T: RealNumber, M: Matrix<T>> PartialEq for SVD<T, M> {
 #[derive(Debug, Clone)]
 /// SVD parameters
 pub struct SVDParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of components to keep.
     pub n_components: usize,
 }
@@ -94,6 +95,7 @@ impl SVDParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct SVDSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Maximum number of iterations of the k-means algorithm for a single run.
     pub n_components: Vec<usize>,
 }

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -69,6 +69,7 @@ impl<T: RealNumber, M: Matrix<T>> PartialEq for SVD<T, M> {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// SVD parameters
 pub struct SVDParameters {

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -67,20 +67,28 @@ use crate::tree::decision_tree_classifier::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RandomForestClassifierParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Split criteria to use when building a tree. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub criterion: SplitCriterion,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub max_depth: Option<u16>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_leaf: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_split: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of trees in the forest.
     pub n_trees: u16,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of random sample of predictors to use as split candidates.
     pub m: Option<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Whether to keep samples used for tree generation. This is required for OOB prediction.
     pub keep_samples: bool,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Seed used for bootstrap sampling and feature selection for each tree.
     pub seed: u64,
 }
@@ -198,20 +206,28 @@ impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for RandomForestCla
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RandomForestClassifierSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Split criteria to use when building a tree. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub criterion: Vec<SplitCriterion>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub max_depth: Vec<Option<u16>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_leaf: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_split: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of trees in the forest.
     pub n_trees: Vec<u16>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of random sample of predictors to use as split candidates.
     pub m: Vec<Option<usize>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Whether to keep samples used for tree generation. This is required for OOB prediction.
     pub keep_samples: Vec<bool>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Seed used for bootstrap sampling and feature selection for each tree.
     pub seed: Vec<u64>,
 }

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -65,18 +65,25 @@ use crate::tree::decision_tree_regressor::{
 /// Parameters of the Random Forest Regressor
 /// Some parameters here are passed directly into base estimator.
 pub struct RandomForestRegressorParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub max_depth: Option<u16>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub min_samples_leaf: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub min_samples_split: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of trees in the forest.
     pub n_trees: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of random sample of predictors to use as split candidates.
     pub m: Option<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Whether to keep samples used for tree generation. This is required for OOB prediction.
     pub keep_samples: bool,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Seed used for bootstrap sampling and feature selection for each tree.
     pub seed: u64,
 }
@@ -181,18 +188,25 @@ impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for RandomForestReg
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RandomForestRegressorSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub max_depth: Vec<Option<u16>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_leaf: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_split: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The number of trees in the forest.
     pub n_trees: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of random sample of predictors to use as split candidates.
     pub m: Vec<Option<usize>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Whether to keep samples used for tree generation. This is required for OOB prediction.
     pub keep_samples: Vec<bool>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Seed used for bootstrap sampling and feature selection for each tree.
     pub seed: Vec<u64>,
 }

--- a/src/linear/elastic_net.rs
+++ b/src/linear/elastic_net.rs
@@ -71,16 +71,21 @@ use crate::linear::lasso_optimizer::InteriorPointOptimizer;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ElasticNetParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The elastic net mixing parameter, with 0 <= l1_ratio <= 1.
     /// For l1_ratio = 0 the penalty is an L2 penalty.
     /// For l1_ratio = 1 it is an L1 penalty. For 0 < l1_ratio < 1, the penalty is a combination of L1 and L2.
     pub l1_ratio: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// If True, the regressors X will be normalized before regression by subtracting the mean and dividing by the standard deviation.
     pub normalize: bool,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The tolerance for the optimization
     pub tol: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum number of iterations
     pub max_iter: usize,
 }
@@ -139,16 +144,21 @@ impl<T: RealNumber> Default for ElasticNetParameters<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ElasticNetSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The elastic net mixing parameter, with 0 <= l1_ratio <= 1.
     /// For l1_ratio = 0 the penalty is an L2 penalty.
     /// For l1_ratio = 1 it is an L1 penalty. For 0 < l1_ratio < 1, the penalty is a combination of L1 and L2.
     pub l1_ratio: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// If True, the regressors X will be normalized before regression by subtracting the mean and dividing by the standard deviation.
     pub normalize: Vec<bool>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The tolerance for the optimization
     pub tol: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum number of iterations
     pub max_iter: Vec<usize>,
 }

--- a/src/linear/lasso.rs
+++ b/src/linear/lasso.rs
@@ -38,13 +38,17 @@ use crate::math::num::RealNumber;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LassoParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the strength of the penalty to the loss function.
     pub alpha: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// If true the regressors X will be normalized before regression
     /// by subtracting the mean and dividing by the standard deviation.
     pub normalize: bool,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The tolerance for the optimization
     pub tol: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum number of iterations
     pub max_iter: usize,
 }
@@ -116,13 +120,17 @@ impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for Lasso<T, M> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LassoSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the strength of the penalty to the loss function.
     pub alpha: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// If true the regressors X will be normalized before regression
     /// by subtracting the mean and dividing by the standard deviation.
     pub normalize: Vec<bool>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The tolerance for the optimization
     pub tol: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum number of iterations
     pub max_iter: Vec<usize>,
 }

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -84,6 +84,7 @@ pub enum LinearRegressionSolverName {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LinearRegressionParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
     pub solver: LinearRegressionSolverName,
 }
@@ -117,6 +118,7 @@ impl Default for LinearRegressionParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LinearRegressionSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
     pub solver: Vec<LinearRegressionSolverName>,
 }
@@ -353,5 +355,9 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&lr).unwrap()).unwrap();
 
         assert_eq!(lr, deserialized_lr);
+
+        let default = LinearRegressionParameters::default();
+        let parameters: LinearRegressionParameters = serde_json::from_str("{}").unwrap();
+        assert_eq!(parameters.solver, default.solver);
     }
 }

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -80,6 +80,12 @@ pub enum LinearRegressionSolverName {
     SVD,
 }
 
+impl Default for LinearRegressionSolverName {
+    fn default() -> Self {
+        LinearRegressionSolverName::SVD
+    }
+}
+
 /// Linear Regression parameters
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -109,7 +115,7 @@ impl LinearRegressionParameters {
 impl Default for LinearRegressionParameters {
     fn default() -> Self {
         LinearRegressionParameters {
-            solver: LinearRegressionSolverName::SVD,
+            solver: LinearRegressionSolverName::default(),
         }
     }
 }

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -71,24 +71,19 @@ use crate::linalg::Matrix;
 use crate::math::num::RealNumber;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 /// Approach to use for estimation of regression coefficients. QR is more efficient but SVD is more stable.
 pub enum LinearRegressionSolverName {
     /// QR decomposition, see [QR](../../linalg/qr/index.html)
     QR,
+    #[default]
     /// SVD decomposition, see [SVD](../../linalg/svd/index.html)
     SVD,
 }
 
-impl Default for LinearRegressionSolverName {
-    fn default() -> Self {
-        LinearRegressionSolverName::SVD
-    }
-}
-
 /// Linear Regression parameters
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct LinearRegressionParameters {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
@@ -109,14 +104,6 @@ impl LinearRegressionParameters {
     pub fn with_solver(mut self, solver: LinearRegressionSolverName) -> Self {
         self.solver = solver;
         self
-    }
-}
-
-impl Default for LinearRegressionParameters {
-    fn default() -> Self {
-        LinearRegressionParameters {
-            solver: LinearRegressionSolverName::default(),
-        }
     }
 }
 

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -75,6 +75,12 @@ pub enum LogisticRegressionSolverName {
     LBFGS,
 }
 
+impl Default for LogisticRegressionSolverName {
+    fn default() -> Self {
+        LogisticRegressionSolverName::LBFGS
+    }
+}
+
 /// Logistic Regression parameters
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -208,7 +214,7 @@ impl<T: RealNumber> LogisticRegressionParameters<T> {
 impl<T: RealNumber> Default for LogisticRegressionParameters<T> {
     fn default() -> Self {
         LogisticRegressionParameters {
-            solver: LogisticRegressionSolverName::LBFGS,
+            solver: LogisticRegressionSolverName::default(),
             alpha: T::zero(),
         }
     }

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -79,8 +79,10 @@ pub enum LogisticRegressionSolverName {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LogisticRegressionParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
     pub solver: LogisticRegressionSolverName,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: T,
 }
@@ -89,8 +91,10 @@ pub struct LogisticRegressionParameters<T: RealNumber> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct LogisticRegressionSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
     pub solver: Vec<LogisticRegressionSolverName>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: Vec<T>,
 }

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -71,8 +71,10 @@ use crate::math::num::RealNumber;
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Approach to use for estimation of regression coefficients. Cholesky is more efficient but SVD is more stable.
 pub enum RidgeRegressionSolverName {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Cholesky decomposition, see [Cholesky](../../linalg/cholesky/index.html)
     Cholesky,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// SVD decomposition, see [SVD](../../linalg/svd/index.html)
     SVD,
 }
@@ -94,10 +96,13 @@ pub struct RidgeRegressionParameters<T: RealNumber> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RidgeRegressionSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Solver to use for estimation of regression coefficients.
     pub solver: Vec<RidgeRegressionSolverName>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// If true the regressors X will be normalized before regression
     /// by subtracting the mean and dividing by the standard deviation.
     pub normalize: Vec<bool>,

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -71,12 +71,16 @@ use crate::math::num::RealNumber;
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Approach to use for estimation of regression coefficients. Cholesky is more efficient but SVD is more stable.
 pub enum RidgeRegressionSolverName {
-    #[cfg_attr(feature = "serde", serde(default))]
     /// Cholesky decomposition, see [Cholesky](../../linalg/cholesky/index.html)
     Cholesky,
-    #[cfg_attr(feature = "serde", serde(default))]
     /// SVD decomposition, see [SVD](../../linalg/svd/index.html)
     SVD,
+}
+
+impl Default for RidgeRegressionSolverName {
+    fn default() -> Self {
+        RidgeRegressionSolverName::Cholesky
+    }
 }
 
 /// Ridge Regression parameters
@@ -209,7 +213,7 @@ impl<T: RealNumber> RidgeRegressionParameters<T> {
 impl<T: RealNumber> Default for RidgeRegressionParameters<T> {
     fn default() -> Self {
         RidgeRegressionParameters {
-            solver: RidgeRegressionSolverName::Cholesky,
+            solver: RidgeRegressionSolverName::default(),
             alpha: T::one(),
             normalize: true,
         }

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -114,10 +114,13 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for BernoulliNBDistributi
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct BernoulliNBParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Option<Vec<T>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Threshold for binarizing (mapping to booleans) of sample features. If None, input is presumed to already consist of binary vectors.
     pub binarize: Option<T>,
 }
@@ -154,10 +157,13 @@ impl<T: RealNumber> Default for BernoulliNBParameters<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct BernoulliNBSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Vec<Option<Vec<T>>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Threshold for binarizing (mapping to booleans) of sample features. If None, input is presumed to already consist of binary vectors.
     pub binarize: Vec<Option<T>>,
 }

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -243,6 +243,7 @@ impl<T: RealNumber> CategoricalNBDistribution<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct CategoricalNBParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: T,
 }
@@ -265,6 +266,7 @@ impl<T: RealNumber> Default for CategoricalNBParameters<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct CategoricalNBSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: Vec<T>,
 }

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -78,6 +78,7 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for GaussianNBDistributio
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct GaussianNBParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Option<Vec<T>>,
 }
@@ -100,6 +101,7 @@ impl<T: RealNumber> Default for GaussianNBParameters<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct GaussianNBSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Vec<Option<Vec<T>>>,
 }

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -86,8 +86,10 @@ impl<T: RealNumber, M: Matrix<T>> NBDistribution<T, M> for MultinomialNBDistribu
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MultinomialNBParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Option<Vec<T>>,
 }
@@ -118,8 +120,10 @@ impl<T: RealNumber> Default for MultinomialNBParameters<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MultinomialNBSearchParameters<T: RealNumber> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
     pub alpha: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
     pub priors: Vec<Option<Vec<T>>>,
 }

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -116,8 +116,8 @@ impl<T: RealNumber> Default for KNNClassifierParameters<T, Euclidian> {
     fn default() -> Self {
         KNNClassifierParameters {
             distance: Distances::euclidian(),
-            algorithm: KNNAlgorithmName::CoverTree,
-            weight: KNNWeightFunction::Uniform,
+            algorithm: KNNAlgorithmName::default(),
+            weight: KNNWeightFunction::default(),
             k: 3,
             t: PhantomData,
         }

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -49,16 +49,21 @@ use crate::neighbors::KNNWeightFunction;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct KNNClassifierParameters<T: RealNumber, D: Distance<Vec<T>, T>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// a function that defines a distance between each pair of point in training data.
     /// This function should extend [`Distance`](../../math/distance/trait.Distance.html) trait.
     /// See [`Distances`](../../math/distance/struct.Distances.html) for a list of available functions.
     pub distance: D,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// backend search algorithm. See [`knn search algorithms`](../../algorithm/neighbour/index.html). `CoverTree` is default.
     pub algorithm: KNNAlgorithmName,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// weighting function that is used to calculate estimated class value. Default function is `KNNWeightFunction::Uniform`.
     pub weight: KNNWeightFunction,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// number of training samples to consider when estimating class for new point. Default value is 3.
     pub k: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// this parameter is not used
     t: PhantomData<T>,
 }

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -118,8 +118,8 @@ impl<T: RealNumber> Default for KNNRegressorParameters<T, Euclidian> {
     fn default() -> Self {
         KNNRegressorParameters {
             distance: Distances::euclidian(),
-            algorithm: KNNAlgorithmName::CoverTree,
-            weight: KNNWeightFunction::Uniform,
+            algorithm: KNNAlgorithmName::default(),
+            weight: KNNWeightFunction::default(),
             k: 3,
             t: PhantomData,
         }

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -52,16 +52,21 @@ use crate::neighbors::KNNWeightFunction;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct KNNRegressorParameters<T: RealNumber, D: Distance<Vec<T>, T>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// a function that defines a distance between each pair of point in training data.
     /// This function should extend [`Distance`](../../math/distance/trait.Distance.html) trait.
     /// See [`Distances`](../../math/distance/struct.Distances.html) for a list of available functions.
     distance: D,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// backend search algorithm. See [`knn search algorithms`](../../algorithm/neighbour/index.html). `CoverTree` is default.
     pub algorithm: KNNAlgorithmName,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// weighting function that is used to calculate estimated class value. Default function is `KNNWeightFunction::Uniform`.
     pub weight: KNNWeightFunction,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// number of training samples to consider when estimating class for new point. Default value is 3.
     pub k: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// this parameter is not used
     t: PhantomData<T>,
 }

--- a/src/neighbors/mod.rs
+++ b/src/neighbors/mod.rs
@@ -58,6 +58,12 @@ pub enum KNNWeightFunction {
     Distance,
 }
 
+impl Default for KNNWeightFunction {
+    fn default() -> Self {
+        KNNWeightFunction::Uniform
+    }
+}
+
 impl KNNWeightFunction {
     fn calc_weights<T: RealNumber>(&self, distances: Vec<T>) -> std::vec::Vec<T> {
         match *self {

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -91,16 +91,22 @@ use crate::svm::{Kernel, Kernels, LinearKernel};
 #[derive(Debug, Clone)]
 /// SVC Parameters
 pub struct SVCParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of epochs.
     pub epoch: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub c: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tolerance for stopping criterion.
     pub tol: T,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The kernel function.
     pub kernel: K,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Unused parameter.
     m: PhantomData<M>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the pseudo random number generation for shuffling the data for probability estimates
     seed: Option<u64>,
 }
@@ -109,16 +115,22 @@ pub struct SVCParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct SVCSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Number of epochs.
     pub epoch: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub c: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tolerance for stopping epoch.
     pub tol: Vec<T>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The kernel function.
     pub kernel: Vec<K>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Unused parameter.
     m: PhantomData<M>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the pseudo random number generation for shuffling the data for probability estimates
     seed: Vec<Option<u64>>,
 }

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -209,14 +209,21 @@ impl Default for DecisionTreeClassifierParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct DecisionTreeClassifierSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Split criteria to use when building a tree. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub criterion: Vec<SplitCriterion>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub max_depth: Vec<Option<u16>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_leaf: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Classifier](../../tree/decision_tree_classifier/index.html)
     pub min_samples_split: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    /// Controls the randomness of the estimator
+    pub seed: Vec<Option<u64>>,
 }
 
 /// DecisionTreeClassifier grid search iterator
@@ -226,6 +233,7 @@ pub struct DecisionTreeClassifierSearchParametersIterator {
     current_max_depth: usize,
     current_min_samples_leaf: usize,
     current_min_samples_split: usize,
+    current_seed: usize,
 }
 
 impl IntoIterator for DecisionTreeClassifierSearchParameters {
@@ -239,6 +247,7 @@ impl IntoIterator for DecisionTreeClassifierSearchParameters {
             current_max_depth: 0,
             current_min_samples_leaf: 0,
             current_min_samples_split: 0,
+            current_seed: 0,
         }
     }
 }
@@ -267,6 +276,7 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
                     .decision_tree_classifier_search_parameters
                     .min_samples_split
                     .len()
+            && self.current_seed == self.decision_tree_classifier_search_parameters.seed.len()
         {
             return None;
         }
@@ -283,6 +293,7 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_classifier_search_parameters
                 .min_samples_split[self.current_min_samples_split],
+            seed: self.decision_tree_classifier_search_parameters.seed[self.current_seed],
         };
 
         if self.current_criterion + 1
@@ -319,11 +330,19 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;
             self.current_min_samples_split += 1;
+        } else if self.current_seed + 1 < self.decision_tree_classifier_search_parameters.seed.len()
+        {
+            self.current_criterion = 0;
+            self.current_max_depth = 0;
+            self.current_min_samples_leaf = 0;
+            self.current_min_samples_split = 0;
+            self.current_seed += 1;
         } else {
             self.current_criterion += 1;
             self.current_max_depth += 1;
             self.current_min_samples_leaf += 1;
             self.current_min_samples_split += 1;
+            self.current_seed += 1;
         }
 
         Some(next)
@@ -339,6 +358,7 @@ impl Default for DecisionTreeClassifierSearchParameters {
             max_depth: vec![default_params.max_depth],
             min_samples_leaf: vec![default_params.min_samples_leaf],
             min_samples_split: vec![default_params.min_samples_split],
+            seed: vec![default_params.seed],
         }
     }
 }

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -281,11 +281,7 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
                     .decision_tree_classifier_search_parameters
                     .min_samples_split
                     .len()
-            && self.current_seed
-                == self
-                    .decision_tree_classifier_search_parameters
-                    .seed
-                    .len()
+            && self.current_seed == self.decision_tree_classifier_search_parameters.seed.len()
         {
             return None;
         }
@@ -302,9 +298,7 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_classifier_search_parameters
                 .min_samples_split[self.current_min_samples_split],
-                seed: self
-                .decision_tree_classifier_search_parameters
-                .seed[self.current_seed],
+            seed: self.decision_tree_classifier_search_parameters.seed[self.current_seed],
         };
 
         if self.current_criterion + 1

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -83,14 +83,19 @@ use crate::rand::get_rng_impl;
 #[derive(Debug, Clone)]
 /// Parameters of Decision Tree
 pub struct DecisionTreeClassifierParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Split criteria to use when building a tree.
     pub criterion: SplitCriterion,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum depth of the tree.
     pub max_depth: Option<u16>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node.
     pub min_samples_leaf: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node.
     pub min_samples_split: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the randomness of the estimator
     pub seed: Option<u64>,
 }
@@ -276,7 +281,11 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
                     .decision_tree_classifier_search_parameters
                     .min_samples_split
                     .len()
-            && self.current_seed == self.decision_tree_classifier_search_parameters.seed.len()
+            && self.current_seed
+                == self
+                    .decision_tree_classifier_search_parameters
+                    .seed
+                    .len()
         {
             return None;
         }
@@ -293,7 +302,9 @@ impl Iterator for DecisionTreeClassifierSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_classifier_search_parameters
                 .min_samples_split[self.current_min_samples_split],
-            seed: self.decision_tree_classifier_search_parameters.seed[self.current_seed],
+                seed: self
+                .decision_tree_classifier_search_parameters
+                .seed[self.current_seed],
         };
 
         if self.current_criterion + 1

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -123,6 +123,12 @@ pub enum SplitCriterion {
     ClassificationError,
 }
 
+impl Default for SplitCriterion {
+    fn default() -> Self {
+        SplitCriterion::Gini
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 struct Node<T: RealNumber> {
@@ -201,7 +207,7 @@ impl DecisionTreeClassifierParameters {
 impl Default for DecisionTreeClassifierParameters {
     fn default() -> Self {
         DecisionTreeClassifierParameters {
-            criterion: SplitCriterion::Gini,
+            criterion: SplitCriterion::default(),
             max_depth: None,
             min_samples_leaf: 1,
             min_samples_split: 2,

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -78,12 +78,16 @@ use crate::rand::get_rng_impl;
 #[derive(Debug, Clone)]
 /// Parameters of Regression Tree
 pub struct DecisionTreeRegressorParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The maximum depth of the tree.
     pub max_depth: Option<u16>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node.
     pub min_samples_leaf: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node.
     pub min_samples_split: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the randomness of the estimator
     pub seed: Option<u64>,
 }
@@ -142,12 +146,16 @@ impl Default for DecisionTreeRegressorParameters {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct DecisionTreeRegressorSearchParameters {
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Tree max depth. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub max_depth: Vec<Option<u16>>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to be at a leaf node. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub min_samples_leaf: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// The minimum number of samples required to split an internal node. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub min_samples_split: Vec<usize>,
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Controls the randomness of the estimator
     pub seed: Vec<Option<u64>>,
 }
@@ -195,7 +203,11 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
                     .decision_tree_regressor_search_parameters
                     .min_samples_split
                     .len()
-            && self.current_seed == self.decision_tree_regressor_search_parameters.seed.len()
+            && self.current_seed
+                == self
+                    .decision_tree_regressor_search_parameters
+                    .seed
+                    .len()
         {
             return None;
         }
@@ -209,7 +221,9 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_regressor_search_parameters
                 .min_samples_split[self.current_min_samples_split],
-            seed: self.decision_tree_regressor_search_parameters.seed[self.current_seed],
+            seed: self
+                .decision_tree_regressor_search_parameters
+                .seed[self.current_seed],
         };
 
         if self.current_max_depth + 1
@@ -236,7 +250,11 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;
             self.current_min_samples_split += 1;
-        } else if self.current_seed + 1 < self.decision_tree_regressor_search_parameters.seed.len()
+        } else if self.current_seed + 1
+            < self
+                .decision_tree_regressor_search_parameters
+                .seed
+                .len()
         {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -148,6 +148,8 @@ pub struct DecisionTreeRegressorSearchParameters {
     pub min_samples_leaf: Vec<usize>,
     /// The minimum number of samples required to split an internal node. See [Decision Tree Regressor](../../tree/decision_tree_regressor/index.html)
     pub min_samples_split: Vec<usize>,
+    /// Controls the randomness of the estimator
+    pub seed: Vec<Option<u64>>,
 }
 
 /// DecisionTreeRegressor grid search iterator
@@ -156,6 +158,7 @@ pub struct DecisionTreeRegressorSearchParametersIterator {
     current_max_depth: usize,
     current_min_samples_leaf: usize,
     current_min_samples_split: usize,
+    current_seed: usize,
 }
 
 impl IntoIterator for DecisionTreeRegressorSearchParameters {
@@ -168,6 +171,7 @@ impl IntoIterator for DecisionTreeRegressorSearchParameters {
             current_max_depth: 0,
             current_min_samples_leaf: 0,
             current_min_samples_split: 0,
+            current_seed: 0,
         }
     }
 }
@@ -191,6 +195,7 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
                     .decision_tree_regressor_search_parameters
                     .min_samples_split
                     .len()
+            && self.current_seed == self.decision_tree_regressor_search_parameters.seed.len()
         {
             return None;
         }
@@ -204,6 +209,7 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_regressor_search_parameters
                 .min_samples_split[self.current_min_samples_split],
+            seed: self.decision_tree_regressor_search_parameters.seed[self.current_seed],
         };
 
         if self.current_max_depth + 1
@@ -230,10 +236,17 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;
             self.current_min_samples_split += 1;
+        } else if self.current_seed + 1 < self.decision_tree_regressor_search_parameters.seed.len()
+        {
+            self.current_max_depth = 0;
+            self.current_min_samples_leaf = 0;
+            self.current_min_samples_split = 0;
+            self.current_seed += 1;
         } else {
             self.current_max_depth += 1;
             self.current_min_samples_leaf += 1;
             self.current_min_samples_split += 1;
+            self.current_seed += 1;
         }
 
         Some(next)
@@ -248,6 +261,7 @@ impl Default for DecisionTreeRegressorSearchParameters {
             max_depth: vec![default_params.max_depth],
             min_samples_leaf: vec![default_params.min_samples_leaf],
             min_samples_split: vec![default_params.min_samples_split],
+            seed: vec![default_params.seed],
         }
     }
 }

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -203,11 +203,7 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
                     .decision_tree_regressor_search_parameters
                     .min_samples_split
                     .len()
-            && self.current_seed
-                == self
-                    .decision_tree_regressor_search_parameters
-                    .seed
-                    .len()
+            && self.current_seed == self.decision_tree_regressor_search_parameters.seed.len()
         {
             return None;
         }
@@ -221,9 +217,7 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             min_samples_split: self
                 .decision_tree_regressor_search_parameters
                 .min_samples_split[self.current_min_samples_split],
-            seed: self
-                .decision_tree_regressor_search_parameters
-                .seed[self.current_seed],
+            seed: self.decision_tree_regressor_search_parameters.seed[self.current_seed],
         };
 
         if self.current_max_depth + 1
@@ -250,11 +244,7 @@ impl Iterator for DecisionTreeRegressorSearchParametersIterator {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;
             self.current_min_samples_split += 1;
-        } else if self.current_seed + 1
-            < self
-                .decision_tree_regressor_search_parameters
-                .seed
-                .len()
+        } else if self.current_seed + 1 < self.decision_tree_regressor_search_parameters.seed.len()
         {
             self.current_max_depth = 0;
             self.current_min_samples_leaf = 0;


### PR DESCRIPTION
Implements #165 for all algorithms.

- SVMSearchParams & DecisionTreeSearchParams were missing the new seeds from regular params, so this completes that update as well.