### PR TITLE
Move to enum Kernels instead of Structs for hypertuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Seeds to multiple algorithims that depend on random number generation.
 - Added feature `js` to use WASM in browser
 
-## BREAKING CHANGE
+## BREAKING CHANGES
+- SVM algorithms now use an enum type of Kernel, rather than distinct structs with a shared trait, so that they may be compared in a single hyperparameter search. 
 - Added a new parameter to `train_test_split` to define the seed.
 
 ## [0.2.1] - 2022-05-10

--- a/src/model_selection/hyper_tuning.rs
+++ b/src/model_selection/hyper_tuning.rs
@@ -60,9 +60,9 @@ where
 
 #[cfg(test)]
 mod tests {
-  use crate::linear::logistic_regression::{
-    LogisticRegression, LogisticRegressionSearchParameters,
-};
+    use crate::linear::logistic_regression::{
+        LogisticRegression, LogisticRegressionSearchParameters,
+    };
 
   #[test]
   fn test_grid_search() {
@@ -113,5 +113,31 @@ mod tests {
       .unwrap();
 
       assert!([0., 1.].contains(&results.parameters.alpha));
-  }
+    }
+
+    #[test]
+    fn svm_check() {
+        let breast_cancer = crate::dataset::breast_cancer::load_dataset();
+        let y = breast_cancer.target;
+        let x = DenseMatrix::from_array(
+            breast_cancer.num_samples,
+            breast_cancer.num_features,
+            &breast_cancer.data,
+        );
+        let kernels = vec![
+            Kernel::Linear,
+            Kernel::RBF { gamma: 0.001 },
+            Kernel::RBF { gamma: 0.0001 },
+        ];
+        let parameters = SVCSearchParameters {
+            kernel: kernels,
+            c: vec![0., 10., 100., 1000.],
+            ..Default::default()
+        };
+        let cv = KFold {
+            n_splits: 5,
+            ..KFold::default()
+        };
+        grid_search(SVC::fit, &x, &y, parameters.into_iter(), cv, &recall).unwrap();
+    }
 }

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -1055,7 +1055,7 @@ mod tests {
 
         let svc = SVC::fit(&x, &y, Default::default()).unwrap();
 
-        let deserialized_svc: SVC<f64, DenseMatrix<f64>, LinearKernel> =
+        let deserialized_svc: SVC<f64, DenseMatrix<f64>> =
             serde_json::from_str(&serde_json::to_string(&svc).unwrap()).unwrap();
 
         assert_eq!(svc, deserialized_svc);

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -28,7 +28,7 @@
 //!
 //! ```
 //! use smartcore::linalg::naive::dense_matrix::*;
-//! use smartcore::svm::Kernels;
+//! use smartcore::svm::Kernel;
 //! use smartcore::svm::svc::{SVC, SVCParameters};
 //!
 //! // Iris dataset
@@ -85,12 +85,12 @@ use crate::linalg::BaseVector;
 use crate::linalg::Matrix;
 use crate::math::num::RealNumber;
 use crate::rand::get_rng_impl;
-use crate::svm::{Kernel, Kernels, LinearKernel};
+use crate::svm::Kernel;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// SVC Parameters
-pub struct SVCParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+pub struct SVCParameters<T: RealNumber, M: Matrix<T>> {
     /// Number of epochs.
     pub epoch: usize,
     /// Regularization parameter.
@@ -98,7 +98,7 @@ pub struct SVCParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>
     /// Tolerance for stopping criterion.
     pub tol: T,
     /// The kernel function.
-    pub kernel: K,
+    pub kernel: Kernel<T>,
     /// Unused parameter.
     m: PhantomData<M>,
     /// Controls the pseudo random number generation for shuffling the data for probability estimates
@@ -108,7 +108,7 @@ pub struct SVCParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>
 /// SVC grid search parameters
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
-pub struct SVCSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+pub struct SVCSearchParameters<T: RealNumber, M: Matrix<T>> {
     /// Number of epochs.
     pub epoch: Vec<usize>,
     /// Regularization parameter.
@@ -116,7 +116,7 @@ pub struct SVCSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowV
     /// Tolerance for stopping epoch.
     pub tol: Vec<T>,
     /// The kernel function.
-    pub kernel: Vec<K>,
+    pub kernel: Vec<Kernel<T>>,
     /// Unused parameter.
     m: PhantomData<M>,
     /// Controls the pseudo random number generation for shuffling the data for probability estimates
@@ -124,8 +124,8 @@ pub struct SVCSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowV
 }
 
 /// SVC grid search iterator
-pub struct SVCSearchParametersIterator<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
-    svc_search_parameters: SVCSearchParameters<T, M, K>,
+pub struct SVCSearchParametersIterator<T: RealNumber, M: Matrix<T>> {
+    svc_search_parameters: SVCSearchParameters<T, M>,
     current_epoch: usize,
     current_c: usize,
     current_tol: usize,
@@ -133,11 +133,9 @@ pub struct SVCSearchParametersIterator<T: RealNumber, M: Matrix<T>, K: Kernel<T,
     current_seed: usize,
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> IntoIterator
-    for SVCSearchParameters<T, M, K>
-{
-    type Item = SVCParameters<T, M, K>;
-    type IntoIter = SVCSearchParametersIterator<T, M, K>;
+impl<T: RealNumber, M: Matrix<T>> IntoIterator for SVCSearchParameters<T, M> {
+    type Item = SVCParameters<T, M>;
+    type IntoIter = SVCSearchParametersIterator<T, M>;
 
     fn into_iter(self) -> Self::IntoIter {
         SVCSearchParametersIterator {
@@ -151,22 +149,20 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> IntoIterator
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
-    for SVCSearchParametersIterator<T, M, K>
-{
-    type Item = SVCParameters<T, M, K>;
+impl<T: RealNumber, M: Matrix<T>> Iterator for SVCSearchParametersIterator<T, M> {
+    type Item = SVCParameters<T, M>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_epoch == self.svc_search_parameters.epoch.len()
             && self.current_c == self.svc_search_parameters.c.len()
             && self.current_tol == self.svc_search_parameters.tol.len()
             && self.current_kernel == self.svc_search_parameters.kernel.len()
-            && self.current_seed == self.svc_search_parameters.kernel.len()
+            && self.current_seed == self.svc_search_parameters.seed.len()
         {
             return None;
         }
 
-        let next = SVCParameters::<T, M, K> {
+        let next = SVCParameters::<T, M> {
             epoch: self.svc_search_parameters.epoch[self.current_epoch],
             c: self.svc_search_parameters.c[self.current_c],
             tol: self.svc_search_parameters.tol[self.current_tol],
@@ -189,7 +185,7 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
             self.current_c = 0;
             self.current_tol = 0;
             self.current_kernel += 1;
-        } else if self.current_kernel + 1 < self.svc_search_parameters.kernel.len() {
+        } else if self.current_seed + 1 < self.svc_search_parameters.seed.len() {
             self.current_epoch = 0;
             self.current_c = 0;
             self.current_tol = 0;
@@ -207,9 +203,9 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Default for SVCSearchParameters<T, M, LinearKernel> {
+impl<T: RealNumber, M: Matrix<T>> Default for SVCSearchParameters<T, M> {
     fn default() -> Self {
-        let default_params: SVCParameters<T, M, LinearKernel> = SVCParameters::default();
+        let default_params: SVCParameters<T, M> = SVCParameters::default();
 
         SVCSearchParameters {
             epoch: vec![default_params.epoch],
@@ -227,14 +223,14 @@ impl<T: RealNumber, M: Matrix<T>> Default for SVCSearchParameters<T, M, LinearKe
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "M::RowVector: Serialize, K: Serialize, T: Serialize",
-        deserialize = "M::RowVector: Deserialize<'de>, K: Deserialize<'de>, T: Deserialize<'de>",
+        serialize = "M::RowVector: Serialize, T: Serialize",
+        deserialize = "M::RowVector: Deserialize<'de>, T: Deserialize<'de>",
     ))
 )]
 /// Support Vector Classifier
-pub struct SVC<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+pub struct SVC<T: RealNumber, M: Matrix<T>> {
     classes: Vec<T>,
-    kernel: K,
+    kernel: Kernel<T>,
     instances: Vec<M::RowVector>,
     w: Vec<T>,
     b: T,
@@ -252,27 +248,27 @@ struct SupportVector<T: RealNumber, V: BaseVector<T>> {
     k: T,
 }
 
-struct Cache<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
-    kernel: &'a K,
+struct Cache<'a, T: RealNumber, M: Matrix<T>> {
+    kernel: &'a Kernel<T>,
     data: HashMap<(usize, usize), T>,
     phantom: PhantomData<M>,
 }
 
-struct Optimizer<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+struct Optimizer<'a, T: RealNumber, M: Matrix<T>> {
     x: &'a M,
     y: &'a M::RowVector,
-    parameters: &'a SVCParameters<T, M, K>,
+    parameters: &'a SVCParameters<T, M>,
     svmin: usize,
     svmax: usize,
     gmin: T,
     gmax: T,
     tau: T,
     sv: Vec<SupportVector<T, M::RowVector>>,
-    kernel: &'a K,
+    kernel: &'a Kernel<T>,
     recalculate_minmax_grad: bool,
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVCParameters<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> SVCParameters<T, M> {
     /// Number of epochs.
     pub fn with_epoch(mut self, epoch: usize) -> Self {
         self.epoch = epoch;
@@ -289,7 +285,7 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVCParameters<T, M
         self
     }
     /// The kernel function.
-    pub fn with_kernel<KK: Kernel<T, M::RowVector>>(&self, kernel: KK) -> SVCParameters<T, M, KK> {
+    pub fn with_kernel(&self, kernel: Kernel<T>) -> SVCParameters<T, M> {
         SVCParameters {
             epoch: self.epoch,
             c: self.c,
@@ -307,36 +303,34 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVCParameters<T, M
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Default for SVCParameters<T, M, LinearKernel> {
+impl<T: RealNumber, M: Matrix<T>> Default for SVCParameters<T, M> {
     fn default() -> Self {
         SVCParameters {
             epoch: 2,
             c: T::one(),
             tol: T::from_f64(1e-3).unwrap(),
-            kernel: Kernels::linear(),
+            kernel: Kernel::default(),
             m: PhantomData,
             seed: None,
         }
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>>
-    SupervisedEstimator<M, M::RowVector, SVCParameters<T, M, K>> for SVC<T, M, K>
+impl<T: RealNumber, M: Matrix<T>> SupervisedEstimator<M, M::RowVector, SVCParameters<T, M>>
+    for SVC<T, M>
 {
-    fn fit(x: &M, y: &M::RowVector, parameters: SVCParameters<T, M, K>) -> Result<Self, Failed> {
+    fn fit(x: &M, y: &M::RowVector, parameters: SVCParameters<T, M>) -> Result<Self, Failed> {
         SVC::fit(x, y, parameters)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Predictor<M, M::RowVector>
-    for SVC<T, M, K>
-{
+impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for SVC<T, M> {
     fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
         self.predict(x)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVC<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> SVC<T, M> {
     /// Fits SVC to your data.
     /// * `x` - _NxM_ matrix with _N_ observations and _M_ features in each observation.
     /// * `y` - class labels
@@ -344,8 +338,8 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVC<T, M, K> {
     pub fn fit(
         x: &M,
         y: &M::RowVector,
-        parameters: SVCParameters<T, M, K>,
-    ) -> Result<SVC<T, M, K>, Failed> {
+        parameters: SVCParameters<T, M>,
+    ) -> Result<SVC<T, M>, Failed> {
         let (n, _) = x.shape();
 
         if n != y.len() {
@@ -422,14 +416,14 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVC<T, M, K> {
         let mut f = self.b;
 
         for i in 0..self.instances.len() {
-            f += self.w[i] * self.kernel.apply(&x, &self.instances[i]);
+            f += self.w[i] * crate::svm::apply(&self.kernel, &x, &self.instances[i]);
         }
 
         f
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> PartialEq for SVC<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> PartialEq for SVC<T, M> {
     fn eq(&self, other: &Self) -> bool {
         if (self.b - other.b).abs() > T::epsilon() * T::two()
             || self.w.len() != other.w.len()
@@ -453,8 +447,8 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> PartialEq for SVC<
 }
 
 impl<T: RealNumber, V: BaseVector<T>> SupportVector<T, V> {
-    fn new<K: Kernel<T, V>>(i: usize, x: V, y: T, g: T, c: T, k: &K) -> SupportVector<T, V> {
-        let k_v = k.apply(&x, &x);
+    fn new(i: usize, x: V, y: T, g: T, c: T, k: &Kernel<T>) -> SupportVector<T, V> {
+        let k_v = crate::svm::apply(k, &x, &x);
         let (cmin, cmax) = if y > T::zero() {
             (T::zero(), c)
         } else {
@@ -472,8 +466,8 @@ impl<T: RealNumber, V: BaseVector<T>> SupportVector<T, V> {
     }
 }
 
-impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Cache<'a, T, M, K> {
-    fn new(kernel: &'a K) -> Cache<'a, T, M, K> {
+impl<'a, T: RealNumber, M: Matrix<T>> Cache<'a, T, M> {
+    fn new(kernel: &'a Kernel<T>) -> Cache<'a, T, M> {
         Cache {
             kernel,
             data: HashMap::new(),
@@ -485,10 +479,10 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Cache<'a, T, M
         let idx_i = i.index;
         let idx_j = j.index;
         #[allow(clippy::or_fun_call)]
-        let entry = self
-            .data
-            .entry((idx_i, idx_j))
-            .or_insert(self.kernel.apply(&i.x, &j.x));
+        let entry =
+            self.data
+                .entry((idx_i, idx_j))
+                .or_insert(crate::svm::apply(self.kernel, &i.x, &j.x));
         *entry
     }
 
@@ -501,13 +495,13 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Cache<'a, T, M
     }
 }
 
-impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, T, M, K> {
+impl<'a, T: RealNumber, M: Matrix<T>> Optimizer<'a, T, M> {
     fn new(
         x: &'a M,
         y: &'a M::RowVector,
-        kernel: &'a K,
-        parameters: &'a SVCParameters<T, M, K>,
-    ) -> Optimizer<'a, T, M, K> {
+        kernel: &'a Kernel<T>,
+        parameters: &'a SVCParameters<T, M>,
+    ) -> Optimizer<'a, T, M> {
         let (n, _) = x.shape();
 
         Optimizer {
@@ -563,7 +557,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         (support_vectors, w, b)
     }
 
-    fn initialize(&mut self, cache: &mut Cache<'_, T, M, K>) {
+    fn initialize(&mut self, cache: &mut Cache<'_, T, M>) {
         let (n, _) = self.x.shape();
         let few = 5;
         let mut cp = 0;
@@ -587,7 +581,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         }
     }
 
-    fn process(&mut self, i: usize, x: M::RowVector, y: T, cache: &mut Cache<'_, T, M, K>) -> bool {
+    fn process(&mut self, i: usize, x: M::RowVector, y: T, cache: &mut Cache<'_, T, M>) -> bool {
         for j in 0..self.sv.len() {
             if self.sv[j].index == i {
                 return true;
@@ -599,7 +593,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         let mut cache_values: Vec<((usize, usize), T)> = Vec::new();
 
         for v in self.sv.iter() {
-            let k = self.kernel.apply(&v.x, &x);
+            let k = crate::svm::apply(self.kernel, &v.x, &x);
             cache_values.push(((i, v.index), k));
             g -= v.alpha * k;
         }
@@ -630,13 +624,13 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         true
     }
 
-    fn reprocess(&mut self, tol: T, cache: &mut Cache<'_, T, M, K>) -> bool {
+    fn reprocess(&mut self, tol: T, cache: &mut Cache<'_, T, M>) -> bool {
         let status = self.smo(None, None, tol, cache);
         self.clean(cache);
         status
     }
 
-    fn finish(&mut self, cache: &mut Cache<'_, T, M, K>) {
+    fn finish(&mut self, cache: &mut Cache<'_, T, M>) {
         let mut max_iter = self.sv.len();
 
         while self.smo(None, None, self.parameters.tol, cache) && max_iter > 0 {
@@ -671,7 +665,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         self.recalculate_minmax_grad = false
     }
 
-    fn clean(&mut self, cache: &mut Cache<'_, T, M, K>) {
+    fn clean(&mut self, cache: &mut Cache<'_, T, M>) {
         self.find_min_max_gradient();
 
         let gmax = self.gmax;
@@ -705,7 +699,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         &mut self,
         idx_1: Option<usize>,
         idx_2: Option<usize>,
-        cache: &mut Cache<'_, T, M, K>,
+        cache: &mut Cache<'_, T, M>,
     ) -> Option<(usize, usize, T)> {
         match (idx_1, idx_2) {
             (None, None) => {
@@ -747,7 +741,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
                         idx_1,
                         idx_2,
                         k_v_12.unwrap_or_else(|| {
-                            self.kernel.apply(&self.sv[idx_1].x, &self.sv[idx_2].x)
+                            crate::svm::apply(self.kernel, &self.sv[idx_1].x, &self.sv[idx_2].x)
                         }),
                     )
                 })
@@ -785,7 +779,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
                         idx_1,
                         idx_2,
                         k_v_12.unwrap_or_else(|| {
-                            self.kernel.apply(&self.sv[idx_1].x, &self.sv[idx_2].x)
+                            crate::svm::apply(self.kernel, &self.sv[idx_1].x, &self.sv[idx_2].x)
                         }),
                     )
                 })
@@ -793,7 +787,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
             (Some(idx_1), Some(idx_2)) => Some((
                 idx_1,
                 idx_2,
-                self.kernel.apply(&self.sv[idx_1].x, &self.sv[idx_2].x),
+                crate::svm::apply(self.kernel, &self.sv[idx_1].x, &self.sv[idx_2].x),
             )),
         }
     }
@@ -803,7 +797,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         idx_1: Option<usize>,
         idx_2: Option<usize>,
         tol: T,
-        cache: &mut Cache<'_, T, M, K>,
+        cache: &mut Cache<'_, T, M>,
     ) -> bool {
         match self.select_pair(idx_1, idx_2, cache) {
             Some((idx_1, idx_2, k_v_12)) => {
@@ -842,7 +836,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
         }
     }
 
-    fn update(&mut self, v1: usize, v2: usize, step: T, cache: &mut Cache<'_, T, M, K>) {
+    fn update(&mut self, v1: usize, v2: usize, step: T, cache: &mut Cache<'_, T, M>) {
         self.sv[v1].alpha -= step;
         self.sv[v2].alpha += step;
 
@@ -867,19 +861,26 @@ mod tests {
 
     #[test]
     fn search_parameters() {
-        let parameters: SVCSearchParameters<f64, DenseMatrix<f64>, LinearKernel> =
-            SVCSearchParameters {
-                epoch: vec![10, 100],
-                kernel: vec![LinearKernel {}],
-                ..Default::default()
-            };
+        let linear = Kernel::Linear;
+        let rbf = Kernel::RBF { gamma: 0.001 };
+        let parameters: SVCSearchParameters<f64, DenseMatrix<f64>> = SVCSearchParameters {
+            epoch: vec![10, 100],
+            kernel: vec![linear, rbf],
+            ..Default::default()
+        };
         let mut iter = parameters.into_iter();
         let next = iter.next().unwrap();
         assert_eq!(next.epoch, 10);
-        assert_eq!(next.kernel, LinearKernel {});
+        assert_eq!(next.kernel, Kernel::Linear);
         let next = iter.next().unwrap();
         assert_eq!(next.epoch, 100);
-        assert_eq!(next.kernel, LinearKernel {});
+        assert_eq!(next.kernel, Kernel::Linear);
+        let next = iter.next().unwrap();
+        assert_eq!(next.epoch, 10);
+        assert_eq!(next.kernel, Kernel::RBF { gamma: 0.001 });
+        let next = iter.next().unwrap();
+        assert_eq!(next.epoch, 100);
+        assert_eq!(next.kernel, Kernel::RBF { gamma: 0.001 });
         assert!(iter.next().is_none());
     }
 
@@ -918,7 +919,7 @@ mod tests {
             &y,
             SVCParameters::default()
                 .with_c(200.0)
-                .with_kernel(Kernels::linear())
+                .with_kernel(Kernel::Linear)
                 .with_seed(Some(100)),
         )
         .and_then(|lr| lr.predict(&x))
@@ -953,7 +954,7 @@ mod tests {
             &y,
             SVCParameters::default()
                 .with_c(200.0)
-                .with_kernel(Kernels::linear()),
+                .with_kernel(Kernel::Linear),
         )
         .and_then(|lr| lr.decision_function(&x2))
         .unwrap();
@@ -1007,7 +1008,7 @@ mod tests {
             &y,
             SVCParameters::default()
                 .with_c(1.0)
-                .with_kernel(Kernels::rbf(0.7)),
+                .with_kernel(Kernel::RBF { gamma: 0.7 }),
         )
         .and_then(|lr| lr.predict(&x))
         .unwrap();

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -714,7 +714,7 @@ mod tests {
 
         let svr = SVR::fit(&x, &y, Default::default()).unwrap();
 
-        let deserialized_svr: SVR<f64, DenseMatrix<f64>, Kernel::Linear> =
+        let deserialized_svr: SVR<f64, DenseMatrix<f64>> =
             serde_json::from_str(&serde_json::to_string(&svr).unwrap()).unwrap();
 
         assert_eq!(svr, deserialized_svr);

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -76,12 +76,12 @@ use crate::error::Failed;
 use crate::linalg::BaseVector;
 use crate::linalg::Matrix;
 use crate::math::num::RealNumber;
-use crate::svm::{Kernel, Kernels, LinearKernel};
+use crate::svm::Kernel;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 /// SVR Parameters
-pub struct SVRParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+pub struct SVRParameters<T: RealNumber, M: Matrix<T>> {
     /// Epsilon in the epsilon-SVR model.
     pub eps: T,
     /// Regularization parameter.
@@ -89,7 +89,7 @@ pub struct SVRParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>
     /// Tolerance for stopping criterion.
     pub tol: T,
     /// The kernel function.
-    pub kernel: K,
+    pub kernel: Kernel<T>,
     /// Unused parameter.
     m: PhantomData<M>,
 }
@@ -97,7 +97,7 @@ pub struct SVRParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>
 /// SVR grid search parameters
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
-pub struct SVRSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+pub struct SVRSearchParameters<T: RealNumber, M: Matrix<T>> {
     /// Epsilon in the epsilon-SVR model.
     pub eps: Vec<T>,
     /// Regularization parameter.
@@ -105,25 +105,23 @@ pub struct SVRSearchParameters<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowV
     /// Tolerance for stopping eps.
     pub tol: Vec<T>,
     /// The kernel function.
-    pub kernel: Vec<K>,
+    pub kernel: Vec<Kernel<T>>,
     /// Unused parameter.
     m: PhantomData<M>,
 }
 
 /// SVR grid search iterator
-pub struct SVRSearchParametersIterator<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
-    svr_search_parameters: SVRSearchParameters<T, M, K>,
+pub struct SVRSearchParametersIterator<T: RealNumber, M: Matrix<T>> {
+    svr_search_parameters: SVRSearchParameters<T, M>,
     current_eps: usize,
     current_c: usize,
     current_tol: usize,
     current_kernel: usize,
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> IntoIterator
-    for SVRSearchParameters<T, M, K>
-{
-    type Item = SVRParameters<T, M, K>;
-    type IntoIter = SVRSearchParametersIterator<T, M, K>;
+impl<T: RealNumber, M: Matrix<T>> IntoIterator for SVRSearchParameters<T, M> {
+    type Item = SVRParameters<T, M>;
+    type IntoIter = SVRSearchParametersIterator<T, M>;
 
     fn into_iter(self) -> Self::IntoIter {
         SVRSearchParametersIterator {
@@ -136,10 +134,8 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> IntoIterator
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
-    for SVRSearchParametersIterator<T, M, K>
-{
-    type Item = SVRParameters<T, M, K>;
+impl<T: RealNumber, M: Matrix<T>> Iterator for SVRSearchParametersIterator<T, M> {
+    type Item = SVRParameters<T, M>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_eps == self.svr_search_parameters.eps.len()
@@ -150,7 +146,7 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
             return None;
         }
 
-        let next = SVRParameters::<T, M, K> {
+        let next = SVRParameters::<T, M> {
             eps: self.svr_search_parameters.eps[self.current_eps],
             c: self.svr_search_parameters.c[self.current_c],
             tol: self.svr_search_parameters.tol[self.current_tol],
@@ -183,9 +179,9 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Iterator
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Default for SVRSearchParameters<T, M, LinearKernel> {
+impl<T: RealNumber, M: Matrix<T>> Default for SVRSearchParameters<T, M> {
     fn default() -> Self {
-        let default_params: SVRParameters<T, M, LinearKernel> = SVRParameters::default();
+        let default_params: SVRParameters<T, M> = SVRParameters::default();
 
         SVRSearchParameters {
             eps: vec![default_params.eps],
@@ -202,14 +198,14 @@ impl<T: RealNumber, M: Matrix<T>> Default for SVRSearchParameters<T, M, LinearKe
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "M::RowVector: Serialize, K: Serialize, T: Serialize",
-        deserialize = "M::RowVector: Deserialize<'de>, K: Deserialize<'de>, T: Deserialize<'de>",
+        serialize = "M::RowVector: Serialize, T: Serialize",
+        deserialize = "M::RowVector: Deserialize<'de>, T: Deserialize<'de>",
     ))
 )]
 
 /// Epsilon-Support Vector Regression
-pub struct SVR<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
-    kernel: K,
+pub struct SVR<T: RealNumber, M: Matrix<T>> {
+    kernel: Kernel<T>,
     instances: Vec<M::RowVector>,
     w: Vec<T>,
     b: T,
@@ -226,7 +222,7 @@ struct SupportVector<T: RealNumber, V: BaseVector<T>> {
 }
 
 /// Sequential Minimal Optimization algorithm
-struct Optimizer<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
+struct Optimizer<'a, T: RealNumber, M: Matrix<T>> {
     tol: T,
     c: T,
     svmin: usize,
@@ -237,14 +233,14 @@ struct Optimizer<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> {
     gmaxindex: usize,
     tau: T,
     sv: Vec<SupportVector<T, M::RowVector>>,
-    kernel: &'a K,
+    kernel: &'a Kernel<T>,
 }
 
 struct Cache<T: Clone> {
     data: Vec<RefCell<Option<Vec<T>>>>,
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVRParameters<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> SVRParameters<T, M> {
     /// Epsilon in the epsilon-SVR model.
     pub fn with_eps(mut self, eps: T) -> Self {
         self.eps = eps;
@@ -261,7 +257,7 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVRParameters<T, M
         self
     }
     /// The kernel function.
-    pub fn with_kernel<KK: Kernel<T, M::RowVector>>(&self, kernel: KK) -> SVRParameters<T, M, KK> {
+    pub fn with_kernel(&self, kernel: Kernel<T>) -> SVRParameters<T, M> {
         SVRParameters {
             eps: self.eps,
             c: self.c,
@@ -272,35 +268,33 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVRParameters<T, M
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>> Default for SVRParameters<T, M, LinearKernel> {
+impl<T: RealNumber, M: Matrix<T>> Default for SVRParameters<T, M> {
     fn default() -> Self {
         SVRParameters {
             eps: T::from_f64(0.1).unwrap(),
             c: T::one(),
             tol: T::from_f64(1e-3).unwrap(),
-            kernel: Kernels::linear(),
+            kernel: Kernel::Linear,
             m: PhantomData,
         }
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>>
-    SupervisedEstimator<M, M::RowVector, SVRParameters<T, M, K>> for SVR<T, M, K>
+impl<T: RealNumber, M: Matrix<T>> SupervisedEstimator<M, M::RowVector, SVRParameters<T, M>>
+    for SVR<T, M>
 {
-    fn fit(x: &M, y: &M::RowVector, parameters: SVRParameters<T, M, K>) -> Result<Self, Failed> {
+    fn fit(x: &M, y: &M::RowVector, parameters: SVRParameters<T, M>) -> Result<Self, Failed> {
         SVR::fit(x, y, parameters)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Predictor<M, M::RowVector>
-    for SVR<T, M, K>
-{
+impl<T: RealNumber, M: Matrix<T>> Predictor<M, M::RowVector> for SVR<T, M> {
     fn predict(&self, x: &M) -> Result<M::RowVector, Failed> {
         self.predict(x)
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVR<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> SVR<T, M> {
     /// Fits SVR to your data.
     /// * `x` - _NxM_ matrix with _N_ observations and _M_ features in each observation.
     /// * `y` - target values
@@ -309,8 +303,8 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVR<T, M, K> {
     pub fn fit(
         x: &M,
         y: &M::RowVector,
-        parameters: SVRParameters<T, M, K>,
-    ) -> Result<SVR<T, M, K>, Failed> {
+        parameters: SVRParameters<T, M>,
+    ) -> Result<SVR<T, M>, Failed> {
         let (n, _) = x.shape();
 
         if n != y.len() {
@@ -349,14 +343,14 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> SVR<T, M, K> {
         let mut f = self.b;
 
         for i in 0..self.instances.len() {
-            f += self.w[i] * self.kernel.apply(&x, &self.instances[i]);
+            f += self.w[i] * crate::svm::apply(&self.kernel, &x, &self.instances[i]);
         }
 
         f
     }
 }
 
-impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> PartialEq for SVR<T, M, K> {
+impl<T: RealNumber, M: Matrix<T>> PartialEq for SVR<T, M> {
     fn eq(&self, other: &Self) -> bool {
         if (self.b - other.b).abs() > T::epsilon() * T::two()
             || self.w.len() != other.w.len()
@@ -380,8 +374,8 @@ impl<T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> PartialEq for SVR<
 }
 
 impl<T: RealNumber, V: BaseVector<T>> SupportVector<T, V> {
-    fn new<K: Kernel<T, V>>(i: usize, x: V, y: T, eps: T, k: &K) -> SupportVector<T, V> {
-        let k_v = k.apply(&x, &x);
+    fn new(i: usize, x: V, y: T, eps: T, k: &Kernel<T>) -> SupportVector<T, V> {
+        let k_v = crate::svm::apply(k, &x, &x);
         SupportVector {
             index: i,
             x,
@@ -392,13 +386,13 @@ impl<T: RealNumber, V: BaseVector<T>> SupportVector<T, V> {
     }
 }
 
-impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, T, M, K> {
+impl<'a, T: RealNumber, M: Matrix<T>> Optimizer<'a, T, M> {
     fn new(
         x: &M,
         y: &M::RowVector,
-        kernel: &'a K,
-        parameters: &SVRParameters<T, M, K>,
-    ) -> Optimizer<'a, T, M, K> {
+        kernel: &'a Kernel<T>,
+        parameters: &SVRParameters<T, M>,
+    ) -> Optimizer<'a, T, M> {
         let (n, _) = x.shape();
 
         let mut support_vectors: Vec<SupportVector<T, M::RowVector>> = Vec::with_capacity(n);
@@ -479,7 +473,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
             let k1 = cache.get(self.sv[v1].index, || {
                 self.sv
                     .iter()
-                    .map(|vi| self.kernel.apply(&self.sv[v1].x, &vi.x))
+                    .map(|vi| crate::svm::apply(self.kernel, &self.sv[v1].x, &vi.x))
                     .collect()
             });
 
@@ -526,7 +520,7 @@ impl<'a, T: RealNumber, M: Matrix<T>, K: Kernel<T, M::RowVector>> Optimizer<'a, 
             let k2 = cache.get(self.sv[v2].index, || {
                 self.sv
                     .iter()
-                    .map(|vi| self.kernel.apply(&self.sv[v2].x, &vi.x))
+                    .map(|vi| crate::svm::apply(self.kernel, &self.sv[v2].x, &vi.x))
                     .collect()
             });
 
@@ -641,19 +635,18 @@ mod tests {
 
     #[test]
     fn search_parameters() {
-        let parameters: SVRSearchParameters<f64, DenseMatrix<f64>, LinearKernel> =
-            SVRSearchParameters {
-                eps: vec![0., 1.],
-                kernel: vec![LinearKernel {}],
-                ..Default::default()
-            };
+        let parameters: SVRSearchParameters<f64, DenseMatrix<f64>> = SVRSearchParameters {
+            eps: vec![0., 1.],
+            kernel: vec![Kernel::Linear {}],
+            ..Default::default()
+        };
         let mut iter = parameters.into_iter();
         let next = iter.next().unwrap();
         assert_eq!(next.eps, 0.);
-        assert_eq!(next.kernel, LinearKernel {});
+        assert_eq!(next.kernel, Kernel::Linear {});
         let next = iter.next().unwrap();
         assert_eq!(next.eps, 1.);
-        assert_eq!(next.kernel, LinearKernel {});
+        assert_eq!(next.kernel, Kernel::Linear {});
         assert!(iter.next().is_none());
     }
 
@@ -721,7 +714,7 @@ mod tests {
 
         let svr = SVR::fit(&x, &y, Default::default()).unwrap();
 
-        let deserialized_svr: SVR<f64, DenseMatrix<f64>, LinearKernel> =
+        let deserialized_svr: SVR<f64, DenseMatrix<f64>, Kernel::Linear> =
             serde_json::from_str(&serde_json::to_string(&svr).unwrap()).unwrap();
 
         assert_eq!(svr, deserialized_svr);


### PR DESCRIPTION
SVCSearchParameters currently uses a Vec<K> for kernels, which means you can't search across multiple kernel types at the same time. This PR converts K to an enum Kernel type, instead of a generic type, so that multiple kinds of kernels may be compared in the same grid search.