### PR TITLE
feat: Create GridSearchCV

### DIFF
--- a/src/model_selection/hyper_tuning/mod.rs
+++ b/src/model_selection/hyper_tuning/mod.rs
@@ -1,2 +1,2 @@
 mod grid_search;
-pub use grid_search::{grid_search, GridSearchResult};
+pub use grid_search::{GridSearchCV, GridSearchCVParameters};

--- a/src/model_selection/mod.rs
+++ b/src/model_selection/mod.rs
@@ -113,7 +113,7 @@ use rand::seq::SliceRandom;
 pub(crate) mod hyper_tuning;
 pub(crate) mod kfold;
 
-pub use hyper_tuning::{grid_search, GridSearchResult};
+pub use hyper_tuning::{GridSearchCV, GridSearchCVParameters};
 pub use kfold::{KFold, KFoldIter};
 
 /// An interface for the K-Folds cross-validator


### PR DESCRIPTION
A little bit of refactoring of the search_grid module to add the GridSearchCV with a similar shape to https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html#

@montanalow please let me know if this sounds good to you. I would love to have this merged before addressing https://github.com/smartcorelib/smartcore/pull/169

