### PR TITLE
build: fix compilation without default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TZ: "/usr/share/zoneinfo/your/location"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache .cargo and target
         uses: actions/cache@v2
         with:
@@ -56,3 +56,34 @@ jobs:
       - name: Tests in WASM
         if: matrix.platform.target == 'wasm32-unknown-unknown'
         run: wasm-pack test --node -- --all-features
+
+  check_features:
+    runs-on: "${{ matrix.platform.os }}-latest"
+    strategy:
+      matrix:
+        platform: [{ os: "ubuntu" }]
+        features: ["--features serde", "--features datasets", ""]
+    env:
+      TZ: "/usr/share/zoneinfo/your/location"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache .cargo and target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo
+            ./target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.platform.target }}
+          profile: minimal
+          default: true
+      - name: Stable Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features ${{ matrix.features }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.toml') }}
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -73,8 +73,8 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-features-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-features-${{ hashFiles('**/Cargo.toml') }}
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,6 @@ bincode = "1.3.1"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[profile.bench]
-debug = true
-
-resolver = "2"
-
 [profile.test]
 debug = 1
 opt-level = 3

--- a/src/linalg/basic/matrix.rs
+++ b/src/linalg/basic/matrix.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 use std::slice::Iter;
 
 use approx::{AbsDiffEq, RelativeEq};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::linalg::basic::arrays::{
@@ -19,7 +20,8 @@ use crate::numbers::basenum::Number;
 use crate::numbers::realnum::RealNumber;
 
 /// Dense matrix
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct DenseMatrix<T> {
     ncols: usize,
     nrows: usize,

--- a/src/numbers/floatnum.rs
+++ b/src/numbers/floatnum.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, Signed};
 
-use crate::numbers::basenum::Number;
+use crate::{numbers::basenum::Number, rand_custom::get_rng_impl};
 
 /// Defines float number
 /// <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_CHTML"></script>
@@ -57,7 +57,7 @@ impl FloatNumber for f64 {
 
     fn rand() -> f64 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = get_rng_impl(None);
         rng.gen()
     }
 
@@ -99,7 +99,7 @@ impl FloatNumber for f32 {
 
     fn rand() -> f32 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = get_rng_impl(None);
         rng.gen()
     }
 

--- a/src/svm/mod.rs
+++ b/src/svm/mod.rs
@@ -52,6 +52,7 @@ impl<'a> Debug for dyn Kernel<'_> + 'a {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a> Serialize for dyn Kernel<'_> + 'a {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -64,7 +65,8 @@ impl<'a> Serialize for dyn Kernel<'_> + 'a {
 }
 
 /// Pre-defined kernel functions
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Kernels {}
 
 impl<'a> Kernels {

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -133,7 +133,7 @@ pub struct SVCParameters<
 pub struct SVC<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>> {
     classes: Option<Vec<TY>>,
     instances: Option<Vec<Vec<TX>>>,
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     parameters: Option<&'a SVCParameters<'a, TX, TY, X, Y>>,
     w: Option<Vec<TX>>,
     b: Option<TX>,

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -92,7 +92,7 @@ pub struct SVRParameters<'a, T: Number + RealNumber> {
     pub c: T,
     /// Tolerance for stopping criterion.
     pub tol: T,
-    #[serde(skip_deserializing)]
+    #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     /// The kernel function.
     pub kernel: Option<&'a dyn Kernel<'a>>,
 }


### PR DESCRIPTION
Fixes #217 and added tests for default target to make sure that we can compile smartcore without the default features

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [ ] Coverage and Linting have been applied 

### Current behaviour
Compiling with `--no-default-features` fails.

### New expected behaviour
Compiling with `--no-default-features` works

