### PR TITLE
Use Box in SVM and remove lifetimes

### DIFF
--- a/src/svm/mod.rs
+++ b/src/svm/mod.rs
@@ -55,7 +55,7 @@ impl Debug for dyn Kernel {
 }
 
 #[cfg(feature = "serde")]
-impl<'a> Serialize for dyn Kernel {
+impl Serialize for dyn Kernel {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -105,7 +105,7 @@ pub struct RBFKernel {
 }
 
 #[allow(dead_code)]
-impl<'a> RBFKernel {
+impl RBFKernel {
     /// assign gamma parameter to kernel (required)
     /// ```rust
     /// use smartcore::svm::RBFKernel;
@@ -129,7 +129,7 @@ pub struct PolynomialKernel {
     pub coef0: Option<f64>,
 }
 
-impl<'a> Default for PolynomialKernel {
+impl Default for PolynomialKernel {
     fn default() -> Self {
         Self {
             gamma: Option::None,
@@ -180,7 +180,7 @@ pub struct SigmoidKernel {
     pub coef0: Option<f64>,
 }
 
-impl<'a> Default for SigmoidKernel {
+impl Default for SigmoidKernel {
     fn default() -> Self {
         Self {
             gamma: Option::None,

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -57,7 +57,7 @@
 //! let y = vec![ -1, -1, -1, -1, -1, -1, -1, -1,
 //!            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
 //!
-//! let knl = Box::new(Kernels::linear());
+//! let knl = Kernels::linear();
 //! let params = &SVCParameters::default().with_c(200.0).with_kernel(knl);
 //! let svc = SVC::fit(&x, &y, params).unwrap();
 //!
@@ -178,8 +178,8 @@ impl<TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
         self
     }
     /// The kernel function.
-    pub fn with_kernel(mut self, kernel: Box<dyn Kernel>) -> Self {
-        self.kernel = Some(kernel);
+    pub fn with_kernel<K: Kernel + 'static>(mut self, kernel: K) -> Self {
+        self.kernel = Some(Box::new(kernel));
         self
     }
 
@@ -973,7 +973,7 @@ mod tests {
         let knl = Kernels::linear();
         let params = SVCParameters::default()
             .with_c(200.0)
-            .with_kernel(Box::new(knl))
+            .with_kernel(knl)
             .with_seed(Some(100));
 
         let y_hat = SVC::fit(&x, &y, &params)
@@ -1012,7 +1012,7 @@ mod tests {
             &y,
             &SVCParameters::default()
                 .with_c(200.0)
-                .with_kernel(Box::new(Kernels::linear())),
+                .with_kernel(Kernels::linear()),
         )
         .and_then(|lr| lr.decision_function(&x2))
         .unwrap();
@@ -1067,7 +1067,7 @@ mod tests {
             &y,
             &SVCParameters::default()
                 .with_c(1.0)
-                .with_kernel(Box::new(Kernels::rbf().with_gamma(0.7))),
+                .with_kernel(Kernels::rbf().with_gamma(0.7)),
         )
         .and_then(|lr| lr.predict(&x))
         .unwrap();
@@ -1116,7 +1116,7 @@ mod tests {
         ];
 
         let knl = Kernels::linear();
-        let params = SVCParameters::default().with_kernel(Box::new(knl));
+        let params = SVCParameters::default().with_kernel(knl);
         let svc = SVC::fit(&x, &y, &params).unwrap();
 
         // serialization

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -159,7 +159,7 @@ struct Optimizer<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y
     recalculate_minmax_grad: bool,
 }
 
-impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
+impl<TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
     SVCParameters<TX, TY, X, Y>
 {
     /// Number of epochs.
@@ -190,7 +190,7 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>
     }
 }
 
-impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>> Default
+impl<TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>> Default
     for SVCParameters<TX, TY, X, Y>
 {
     fn default() -> Self {

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -140,7 +140,7 @@ struct Cache<T: Clone> {
     data: Vec<RefCell<Option<Vec<T>>>>,
 }
 
-impl<'a, T: Number + FloatNumber + PartialOrd> SVRParameters<T> {
+impl<T: Number + FloatNumber + PartialOrd> SVRParameters<T> {
     /// Epsilon in the epsilon-SVR model.
     pub fn with_eps(mut self, eps: T) -> Self {
         self.eps = eps;
@@ -163,7 +163,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd> SVRParameters<T> {
     }
 }
 
-impl<'a, T: Number + FloatNumber + PartialOrd> Default for SVRParameters<T> {
+impl<T: Number + FloatNumber + PartialOrd> Default for SVRParameters<T> {
     fn default() -> Self {
         SVRParameters {
             eps: T::from_f64(0.1).unwrap(),

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -49,7 +49,7 @@
 //! let y: Vec<f64> = vec![83.0, 88.5, 88.2, 89.5, 96.2, 98.1, 99.0,
 //!           100.0, 101.2, 104.6, 108.4, 110.8, 112.6, 114.2, 115.7, 116.9];
 //!
-//! let knl = Box::new(Kernels::linear());
+//! let knl = Kernels::linear();
 //! let params = &SVRParameters::default().with_eps(2.0).with_c(10.0).with_kernel(knl);
 //! // let svr = SVR::fit(&x, &y, params).unwrap();
 //!
@@ -157,8 +157,8 @@ impl<T: Number + FloatNumber + PartialOrd> SVRParameters<T> {
         self
     }
     /// The kernel function.
-    pub fn with_kernel(mut self, kernel: Box<dyn Kernel>) -> Self {
-        self.kernel = Some(kernel);
+    pub fn with_kernel<K: Kernel + 'static>(mut self, kernel: K) -> Self {
+        self.kernel = Some(Box::new(kernel));
         self
     }
 }
@@ -655,7 +655,7 @@ mod tests {
             &SVRParameters::default()
                 .with_eps(2.0)
                 .with_c(10.0)
-                .with_kernel(Box::new(knl)),
+                .with_kernel(knl),
         )
         .and_then(|lr| lr.predict(&x))
         .unwrap();
@@ -697,7 +697,7 @@ mod tests {
         ];
 
         let knl = Kernels::rbf().with_gamma(0.7);
-        let params = SVRParameters::default().with_kernel(Box::new(knl));
+        let params = SVRParameters::default().with_kernel(knl);
 
         let svr = SVR::fit(&x, &y, &params).unwrap();
 

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -49,8 +49,8 @@
 //! let y: Vec<f64> = vec![83.0, 88.5, 88.2, 89.5, 96.2, 98.1, 99.0,
 //!           100.0, 101.2, 104.6, 108.4, 110.8, 112.6, 114.2, 115.7, 116.9];
 //!
-//! let knl = Kernels::linear();
-//! let params = &SVRParameters::default().with_eps(2.0).with_c(10.0).with_kernel(&knl);
+//! let knl = Box::new(Kernels::linear());
+//! let params = &SVRParameters::default().with_eps(2.0).with_c(10.0).with_kernel(knl);
 //! // let svr = SVR::fit(&x, &y, params).unwrap();
 //!
 //! // let y_hat = svr.predict(&x).unwrap();
@@ -83,9 +83,9 @@ use crate::numbers::floatnum::FloatNumber;
 use crate::svm::Kernel;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 /// SVR Parameters
-pub struct SVRParameters<'a, T: Number + FloatNumber + PartialOrd> {
+pub struct SVRParameters<T: Number + FloatNumber + PartialOrd> {
     /// Epsilon in the epsilon-SVR model.
     pub eps: T,
     /// Regularization parameter.
@@ -94,7 +94,7 @@ pub struct SVRParameters<'a, T: Number + FloatNumber + PartialOrd> {
     pub tol: T,
     #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     /// The kernel function.
-    pub kernel: Option<&'a dyn Kernel<'a>>,
+    pub kernel: Option<Box<dyn Kernel>>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -103,7 +103,7 @@ pub struct SVRParameters<'a, T: Number + FloatNumber + PartialOrd> {
 pub struct SVR<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> {
     instances: Option<Vec<Vec<f64>>>,
     #[cfg_attr(feature = "serde", serde(skip_deserializing))]
-    parameters: Option<&'a SVRParameters<'a, T>>,
+    parameters: Option<&'a SVRParameters<T>>,
     w: Option<Vec<T>>,
     b: T,
     phantom: PhantomData<(X, Y)>,
@@ -123,7 +123,7 @@ struct SupportVector<T> {
 struct Optimizer<'a, T: Number + FloatNumber + PartialOrd> {
     tol: T,
     c: T,
-    parameters: Option<&'a SVRParameters<'a, T>>,
+    parameters: Option<&'a SVRParameters<T>>,
     svmin: usize,
     svmax: usize,
     gmin: T,
@@ -140,7 +140,7 @@ struct Cache<T: Clone> {
     data: Vec<RefCell<Option<Vec<T>>>>,
 }
 
-impl<'a, T: Number + FloatNumber + PartialOrd> SVRParameters<'a, T> {
+impl<'a, T: Number + FloatNumber + PartialOrd> SVRParameters<T> {
     /// Epsilon in the epsilon-SVR model.
     pub fn with_eps(mut self, eps: T) -> Self {
         self.eps = eps;
@@ -157,13 +157,13 @@ impl<'a, T: Number + FloatNumber + PartialOrd> SVRParameters<'a, T> {
         self
     }
     /// The kernel function.
-    pub fn with_kernel(mut self, kernel: &'a (dyn Kernel<'a>)) -> Self {
+    pub fn with_kernel(mut self, kernel: Box<dyn Kernel>) -> Self {
         self.kernel = Some(kernel);
         self
     }
 }
 
-impl<'a, T: Number + FloatNumber + PartialOrd> Default for SVRParameters<'a, T> {
+impl<'a, T: Number + FloatNumber + PartialOrd> Default for SVRParameters<T> {
     fn default() -> Self {
         SVRParameters {
             eps: T::from_f64(0.1).unwrap(),
@@ -175,7 +175,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd> Default for SVRParameters<'a, T> 
 }
 
 impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>>
-    SupervisedEstimatorBorrow<'a, X, Y, SVRParameters<'a, T>> for SVR<'a, T, X, Y>
+    SupervisedEstimatorBorrow<'a, X, Y, SVRParameters<T>> for SVR<'a, T, X, Y>
 {
     fn new() -> Self {
         Self {
@@ -186,7 +186,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>>
             phantom: PhantomData,
         }
     }
-    fn fit(x: &'a X, y: &'a Y, parameters: &'a SVRParameters<'a, T>) -> Result<Self, Failed> {
+    fn fit(x: &'a X, y: &'a Y, parameters: &'a SVRParameters<T>) -> Result<Self, Failed> {
         SVR::fit(x, y, parameters)
     }
 }
@@ -208,7 +208,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> SVR<'
     pub fn fit(
         x: &'a X,
         y: &'a Y,
-        parameters: &'a SVRParameters<'a, T>,
+        parameters: &'a SVRParameters<T>,
     ) -> Result<SVR<'a, T, X, Y>, Failed> {
         let (n, _) = x.shape();
 
@@ -324,7 +324,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd> Optimizer<'a, T> {
     fn new<X: Array2<T>, Y: Array1<T>>(
         x: &'a X,
         y: &'a Y,
-        parameters: &'a SVRParameters<'a, T>,
+        parameters: &'a SVRParameters<T>,
     ) -> Optimizer<'a, T> {
         let (n, _) = x.shape();
 
@@ -655,7 +655,7 @@ mod tests {
             &SVRParameters::default()
                 .with_eps(2.0)
                 .with_c(10.0)
-                .with_kernel(&knl),
+                .with_kernel(Box::new(knl)),
         )
         .and_then(|lr| lr.predict(&x))
         .unwrap();
@@ -697,7 +697,7 @@ mod tests {
         ];
 
         let knl = Kernels::rbf().with_gamma(0.7);
-        let params = SVRParameters::default().with_kernel(&knl);
+        let params = SVRParameters::default().with_kernel(Box::new(knl));
 
         let svr = SVR::fit(&x, &y, &params).unwrap();
 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #

* Remove lifetimes in Kernel trait.
* Use box instead of & for Kernel objects n SVM structs.
* 
### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied 

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
