### PR TITLE
chore: fix clippy warnings from Rust release 1.69

### DIFF
--- a/src/linalg/basic/matrix.rs
+++ b/src/linalg/basic/matrix.rs
@@ -431,9 +431,9 @@ impl<T: Number + RealNumber> SVDDecomposable<T> for DenseMatrix<T> {}
 impl<'a, T: Debug + Display + Copy + Sized> Array<T, (usize, usize)> for DenseMatrixView<'a, T> {
     fn get(&self, pos: (usize, usize)) -> &T {
         if self.column_major {
-            &self.values[(pos.0 + pos.1 * self.stride)]
+            &self.values[pos.0 + pos.1 * self.stride]
         } else {
-            &self.values[(pos.0 * self.stride + pos.1)]
+            &self.values[pos.0 * self.stride + pos.1]
         }
     }
 
@@ -495,9 +495,9 @@ impl<'a, T: Debug + Display + Copy + Sized> ArrayView1<T> for DenseMatrixView<'a
 impl<'a, T: Debug + Display + Copy + Sized> Array<T, (usize, usize)> for DenseMatrixMutView<'a, T> {
     fn get(&self, pos: (usize, usize)) -> &T {
         if self.column_major {
-            &self.values[(pos.0 + pos.1 * self.stride)]
+            &self.values[pos.0 + pos.1 * self.stride]
         } else {
-            &self.values[(pos.0 * self.stride + pos.1)]
+            &self.values[pos.0 * self.stride + pos.1]
         }
     }
 
@@ -519,9 +519,9 @@ impl<'a, T: Debug + Display + Copy + Sized> MutArray<T, (usize, usize)>
 {
     fn set(&mut self, pos: (usize, usize), x: T) {
         if self.column_major {
-            self.values[(pos.0 + pos.1 * self.stride)] = x;
+            self.values[pos.0 + pos.1 * self.stride] = x;
         } else {
-            self.values[(pos.0 * self.stride + pos.1)] = x;
+            self.values[pos.0 * self.stride + pos.1] = x;
         }
     }
 

--- a/src/model_selection/kfold.rs
+++ b/src/model_selection/kfold.rs
@@ -283,9 +283,7 @@ mod tests {
             (vec![0, 1, 2, 3, 7, 8, 9], vec![4, 5, 6]),
             (vec![0, 1, 2, 3, 4, 5, 6], vec![7, 8, 9]),
         ];
-        for ((train, test), (expected_train, expected_test)) in
-            k.split(&x).zip(expected)
-        {
+        for ((train, test), (expected_train, expected_test)) in k.split(&x).zip(expected) {
             assert_eq!(test, expected_test);
             assert_eq!(train, expected_train);
         }
@@ -307,9 +305,7 @@ mod tests {
             (vec![0, 1, 2, 3, 7, 8, 9], vec![4, 5, 6]),
             (vec![0, 1, 2, 3, 4, 5, 6], vec![7, 8, 9]),
         ];
-        for ((train, test), (expected_train, expected_test)) in
-            k.split(&x).zip(expected)
-        {
+        for ((train, test), (expected_train, expected_test)) in k.split(&x).zip(expected) {
             assert_eq!(test.len(), expected_test.len());
             assert_eq!(train.len(), expected_train.len());
         }

--- a/src/model_selection/kfold.rs
+++ b/src/model_selection/kfold.rs
@@ -284,7 +284,7 @@ mod tests {
             (vec![0, 1, 2, 3, 4, 5, 6], vec![7, 8, 9]),
         ];
         for ((train, test), (expected_train, expected_test)) in
-            k.split(&x).into_iter().zip(expected)
+            k.split(&x).zip(expected)
         {
             assert_eq!(test, expected_test);
             assert_eq!(train, expected_train);
@@ -308,7 +308,7 @@ mod tests {
             (vec![0, 1, 2, 3, 4, 5, 6], vec![7, 8, 9]),
         ];
         for ((train, test), (expected_train, expected_test)) in
-            k.split(&x).into_iter().zip(expected)
+            k.split(&x).zip(expected)
         {
             assert_eq!(test.len(), expected_test.len());
             assert_eq!(train.len(), expected_train.len());

--- a/src/readers/csv.rs
+++ b/src/readers/csv.rs
@@ -83,7 +83,7 @@ where
     Matrix: Array2<T>,
 {
     let csv_text = read_string_from_source(source)?;
-    let rows: Vec<Vec<T>> = extract_row_vectors_from_csv_text::<T, RowVector, Matrix>(
+    let rows: Vec<Vec<T>> = extract_row_vectors_from_csv_text(
         &csv_text,
         &definition,
         detect_row_format(&csv_text, &definition)?,
@@ -103,12 +103,7 @@ where
 
 /// Given a string containing the contents of a csv file, extract its value
 /// into row-vectors.
-fn extract_row_vectors_from_csv_text<
-    'a,
-    T: Number + RealNumber + std::str::FromStr,
-    RowVector: Array1<T>,
-    Matrix: Array2<T>,
->(
+fn extract_row_vectors_from_csv_text<'a, T: Number + RealNumber + std::str::FromStr>(
     csv_text: &'a str,
     definition: &'a CSVDefinition<'_>,
     row_format: CSVRowFormat<'_>,
@@ -305,12 +300,11 @@ mod tests {
     }
     mod extract_row_vectors_from_csv_text {
         use super::super::{extract_row_vectors_from_csv_text, CSVDefinition, CSVRowFormat};
-        use crate::linalg::basic::matrix::DenseMatrix;
 
         #[test]
         fn read_default_csv() {
             assert_eq!(
-                extract_row_vectors_from_csv_text::<f64, Vec<_>, DenseMatrix<_>>(
+                extract_row_vectors_from_csv_text::<f64>(
                     "column 1, column 2, column3\n1.0,2.0,3.0\n4.0,5.0,6.0",
                     &CSVDefinition::default(),
                     CSVRowFormat {


### PR DESCRIPTION
Fixed running `cargo clippy --fix`