### PR TITLE
In Naive Bayes, avoid using `Option::unwrap` and so avoid panicking from NaN values

### DIFF
--- a/src/model_selection/hyper_tuning/grid_search.rs
+++ b/src/model_selection/hyper_tuning/grid_search.rs
@@ -3,9 +3,9 @@
 use crate::{
     api::{Predictor, SupervisedEstimator},
     error::{Failed, FailedError},
-    linalg::basic::arrays::{Array2, Array1},
-    numbers::realnum::RealNumber,
+    linalg::basic::arrays::{Array1, Array2},
     numbers::basenum::Number,
+    numbers::realnum::RealNumber,
 };
 
 use crate::model_selection::{cross_validate, BaseKFold, CrossValidationResult};


### PR DESCRIPTION
Fixes #273 

### Checklist
- [X] My branch is up-to-date with development branch.
- [X] Everything works and tested on latest stable Rust.
- [X] Coverage and Linting have been applied 

### Current behaviour
Panics in function `naive_bayes::BaseNaiveBayes::predict`

### New expected behaviour
No panics with NaNs
