### PR TITLE
set min similarity for constant zeros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smartcore"
 description = "Machine Learning in Rust."
 homepage = "https://smartcorelib.org"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["smartcore Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/metrics/distance/cosine.rs
+++ b/src/metrics/distance/cosine.rs
@@ -92,7 +92,7 @@ impl<T: Number> Cosine<T> {
         let magnitude_y = Self::magnitude(y);
 
         if magnitude_x == 0.0 || magnitude_y == 0.0 {
-            panic!("Cannot compute cosine distance for zero-magnitude vectors.");
+            return f64::MIN;
         }
 
         dot_product / (magnitude_x * magnitude_y)
@@ -188,12 +188,12 @@ mod tests {
         wasm_bindgen_test::wasm_bindgen_test
     )]
     #[test]
-    #[should_panic(expected = "Cannot compute cosine distance for zero-magnitude vectors.")]
     fn cosine_distance_zero_vector() {
         let a = vec![0, 0, 0];
         let b = vec![1, 2, 3];
 
-        let _dist: f64 = Cosine::new().distance(&a, &b);
+        let dist: f64 = Cosine::new().distance(&a, &b);
+        assert!(dist > 1e300)
     }
 
     #[cfg_attr(


### PR DESCRIPTION
In case of a zero-magnitude vector is passed to cosine distance, max distance should be returned

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied 

### Current behaviour
cosine distance panics for zero-magnitude vectors

### New expected behaviour
cosine distance returns `f64::MIN` in case of zero-magnitude vectors
