### PR TITLE
in cover_tree.rs i64::MIN - 1 causes overflow. FIXED.

### DIFF
--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -290,7 +290,10 @@ impl<T: Debug + PartialEq, D: Distance<T>> CoverTree<T, D> {
             self.new_leaf(p)
         } else {
             let max_dist = self.max(point_set);
-            let next_scale = max_scale.checked_sub(1).map(|s| s.min(self.get_scale(max_dist))).unwrap_or(i64::MIN); // bugfix i64::MIN - 1 causes overflow
+            let next_scale = max_scale // bugfix i64::MIN - 1 causes overflow
+                .checked_sub(1) // returns None if overflow
+                .map(|s| s.min(self.get_scale(max_dist)))
+                .unwrap_or(i64::MIN); // safely getting required value
             if next_scale == i64::MIN {
                 let mut children: Vec<Node> = Vec::new();
                 let mut leaf = self.new_leaf(p);

--- a/src/algorithm/neighbour/cover_tree.rs
+++ b/src/algorithm/neighbour/cover_tree.rs
@@ -290,7 +290,7 @@ impl<T: Debug + PartialEq, D: Distance<T>> CoverTree<T, D> {
             self.new_leaf(p)
         } else {
             let max_dist = self.max(point_set);
-            let next_scale = (max_scale - 1).min(self.get_scale(max_dist));
+            let next_scale = max_scale.checked_sub(1).map(|s| s.min(self.get_scale(max_dist))).unwrap_or(i64::MIN); // bugfix i64::MIN - 1 causes overflow
             if next_scale == i64::MIN {
                 let mut children: Vec<Node> = Vec::new();
                 let mut leaf = self.new_leaf(p);

--- a/src/metrics/distance/jaccard.rs
+++ b/src/metrics/distance/jaccard.rs
@@ -89,7 +89,6 @@ mod tests {
         all(target_arch = "wasm32", not(target_os = "wasi")),
         wasm_bindgen_test::wasm_bindgen_test
     )]
-
     #[test]
     fn jaccard_distance() {
         let a = vec![1, 0, 1, 1];
@@ -133,4 +132,3 @@ mod tests {
         assert!((d1 - d2).abs() < 1e-12);
     }
 }
-


### PR DESCRIPTION

### Checklist
- [ yes ] My branch is up-to-date with development branch.
- [ yes ] Everything works and tested on latest stable Rust.
- [ yes ] Coverage and Linting have been applied 

Im about to implement predict_proba for kNN. Extensive tests show a bug in cover_tree.rs.

When d = 0 an attempt to do i64::MIN - 1 is performed.

So this PR is a fix of it.