### PR TITLE
chore: bump rand to 0.10.1, rand_distr to 0.5, getrandom to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ std_rand = ["rand/std_rng", "rand/std", "rand/thread_rng"]
 js = ["getrandom/wasm_js"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3", optional = true }
+getrandom = { version = "0.4", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ ndarray = { version = "0.15", optional = true }
 num-traits = "0.2.12"
 num = "0.4"
 rand = { version = "0.10.1", default-features = false, features = ["alloc"] }
-rand_distr = { version = "0.5.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 ordered-float = "5.1.0"
 
@@ -37,7 +36,7 @@ typetag = { version = "0.2", optional = true }
 default = []
 serde = ["dep:serde", "dep:typetag"]
 ndarray-bindings = ["dep:ndarray"]
-datasets = ["dep:rand_distr", "std_rand", "serde"]
+datasets = ["std_rand", "serde"]
 std_rand = ["rand/std_rng", "rand/std", "rand/thread_rng"]
 # used by wasm32-unknown-unknown for in-browser usage
 js = ["getrandom/wasm_js"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ndarray = { version = "0.15", optional = true }
 num-traits = "0.2.12"
 num = "0.4"
 rand = { version = "0.10.1", default-features = false, features = ["alloc"] }
-rand_distr = { version = "0.5", optional = true }
+rand_distr = { version = "0.5.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 ordered-float = "5.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "1.0.0"
 ndarray = { version = "0.15", optional = true }
 num-traits = "0.2.12"
 num = "0.4"
-rand = { version = "0.10.1", default-features = false, features = ["small_rng"] }
+rand = { version = "0.10.1", default-features = false, features = ["alloc"] }
 rand_distr = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 ordered-float = "5.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ndarray = { version = "0.15", optional = true }
 num-traits = "0.2.12"
 num = "0.4"
 rand = { version = "0.10.1", default-features = false, features = ["alloc"] }
+rand_distr = { version = "0.5.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 ordered-float = "5.1.0"
 
@@ -36,7 +37,7 @@ typetag = { version = "0.2", optional = true }
 default = []
 serde = ["dep:serde", "dep:typetag"]
 ndarray-bindings = ["dep:ndarray"]
-datasets = ["std_rand", "serde"]
+datasets = ["dep:rand_distr", "std_rand", "serde"]
 std_rand = ["rand/std_rng", "rand/std", "rand/thread_rng"]
 # used by wasm32-unknown-unknown for in-browser usage
 js = ["getrandom/wasm_js"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ cfg-if = "1.0.0"
 ndarray = { version = "0.15", optional = true }
 num-traits = "0.2.12"
 num = "0.4"
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-rand_distr = { version = "0.4", optional = true }
+rand = { version = "0.10.1", default-features = false, features = ["small_rng"] }
+rand_distr = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 ordered-float = "5.1.0"
 
@@ -38,12 +38,12 @@ default = []
 serde = ["dep:serde", "dep:typetag"]
 ndarray-bindings = ["dep:ndarray"]
 datasets = ["dep:rand_distr", "std_rand", "serde"]
-std_rand = ["rand/std_rng", "rand/std"]
+std_rand = ["rand/std_rng", "rand/std", "rand/thread_rng"]
 # used by wasm32-unknown-unknown for in-browser usage
-js = ["getrandom/js"]
+js = ["getrandom/wasm_js"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.8", optional = true }
+getrandom = { version = "0.3", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -55,7 +55,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use rand::Rng;
+use rand::RngExt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -356,7 +356,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
         let (n, _) = data.shape();
         let mut y = vec![0; n];
         let mut centroid: Vec<TX> = data
-            .get_row(rng.gen_range(0..n))
+            .get_row(rng.random_range(0..n))
             .iterator(0)
             .cloned()
             .collect();
@@ -382,7 +382,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
             for i in d.iter() {
                 sum += *i;
             }
-            let cutoff = rng.gen::<f64>() * sum;
+            let cutoff = rng.random::<f64>() * sum;
             let mut cost = 0f64;
             let mut index = 0;
             while index < n {

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -3,6 +3,7 @@
 use rand::distr::Distribution;
 use rand::distr::Uniform;
 use rand::prelude::*;
+use rand_distr::Distribution as DistrDistribution;
 use rand_distr::Normal;
 
 use crate::dataset::Dataset;
@@ -33,7 +34,7 @@ pub fn make_blobs(
         let label = i % num_centers;
         y.push(label as f32);
         for j in 0..num_features {
-            x.push(centers[label][j].sample(&mut rng));
+            x.push(DistrDistribution::sample(&centers[label][j], &mut rng));
         }
     }
 
@@ -67,14 +68,14 @@ pub fn make_circles(num_samples: usize, factor: f32, noise: f32) -> Dataset<f32,
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + noise.sample(&mut rng));
-        x.push(v.sin() + noise.sample(&mut rng));
+        x.push(v.cos() + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.sin() + DistrDistribution::sample(&noise, &mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(v.cos() * factor + noise.sample(&mut rng));
-        x.push(v.sin() * factor + noise.sample(&mut rng));
+        x.push(v.cos() * factor + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.sin() * factor + DistrDistribution::sample(&noise, &mut rng));
         y.push(1.0);
     }
 
@@ -104,14 +105,14 @@ pub fn make_moons(num_samples: usize, noise: f32) -> Dataset<f32, u32> {
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + noise.sample(&mut rng));
-        x.push(v.sin() + noise.sample(&mut rng));
+        x.push(v.cos() + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.sin() + DistrDistribution::sample(&noise, &mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(1.0 - v.cos() + noise.sample(&mut rng));
-        x.push(1.0 - v.sin() + noise.sample(&mut rng) - 0.5);
+        x.push(1.0 - v.cos() + DistrDistribution::sample(&noise, &mut rng));
+        x.push(1.0 - v.sin() + DistrDistribution::sample(&noise, &mut rng) - 0.5);
         y.push(1.0);
     }
 

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,15 +1,18 @@
 //! # Dataset Generators
 //!
 use rand::distr::Distribution;
-use rand::distr::StandardNormal;
 use rand::distr::Uniform;
 
 use crate::dataset::Dataset;
 
-/// Sample from N(mean, std) using rand 0.10's StandardNormal
+/// Sample from N(mean, std) via Box-Muller transform using only rand 0.10
 #[inline]
 fn sample_normal(mean: f32, std: f32, rng: &mut impl rand::Rng) -> f32 {
-    mean + std * StandardNormal.sample(rng)
+    let unit = Uniform::new(f32::EPSILON, 1.0f32).unwrap();
+    let u1 = unit.sample(rng);
+    let u2 = unit.sample(rng);
+    let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
+    mean + std * z
 }
 
 /// Generate `num_centers` clusters of normally distributed points
@@ -22,7 +25,7 @@ pub fn make_blobs(
     let cluster_std = 1.0f32;
     let mut rng = rand::rng();
 
-    // Pre-compute cluster centers (mean values per feature)
+    // Pre-compute cluster centers (one mean per feature per cluster)
     let centers: Vec<Vec<f32>> = (0..num_centers)
         .map(|_| {
             (0..num_features)

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,8 +1,8 @@
 //! # Dataset Generators
 //!
+use rand::distr::Distribution;
 use rand::distr::Uniform;
 use rand::prelude::*;
-use rand_distr::Distribution;
 use rand_distr::Normal;
 
 use crate::dataset::Dataset;

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,10 +1,9 @@
 //! # Dataset Generators
 //!
 use rand::distr::Distribution;
+use rand::distr::Normal;
 use rand::distr::Uniform;
 use rand::prelude::*;
-use rand_distr::Distribution as DistrDistribution;
-use rand_distr::Normal;
 
 use crate::dataset::Dataset;
 
@@ -34,7 +33,7 @@ pub fn make_blobs(
         let label = i % num_centers;
         y.push(label as f32);
         for j in 0..num_features {
-            x.push(DistrDistribution::sample(&centers[label][j], &mut rng));
+            x.push(centers[label][j].sample(&mut rng));
         }
     }
 
@@ -68,14 +67,14 @@ pub fn make_circles(num_samples: usize, factor: f32, noise: f32) -> Dataset<f32,
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + DistrDistribution::sample(&noise, &mut rng));
-        x.push(v.sin() + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.cos() + noise.sample(&mut rng));
+        x.push(v.sin() + noise.sample(&mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(v.cos() * factor + DistrDistribution::sample(&noise, &mut rng));
-        x.push(v.sin() * factor + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.cos() * factor + noise.sample(&mut rng));
+        x.push(v.sin() * factor + noise.sample(&mut rng));
         y.push(1.0);
     }
 
@@ -105,14 +104,14 @@ pub fn make_moons(num_samples: usize, noise: f32) -> Dataset<f32, u32> {
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + DistrDistribution::sample(&noise, &mut rng));
-        x.push(v.sin() + DistrDistribution::sample(&noise, &mut rng));
+        x.push(v.cos() + noise.sample(&mut rng));
+        x.push(v.sin() + noise.sample(&mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(1.0 - v.cos() + DistrDistribution::sample(&noise, &mut rng));
-        x.push(1.0 - v.sin() + DistrDistribution::sample(&noise, &mut rng) - 0.5);
+        x.push(1.0 - v.cos() + noise.sample(&mut rng));
+        x.push(1.0 - v.sin() + noise.sample(&mut rng) - 0.5);
         y.push(1.0);
     }
 

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -2,6 +2,7 @@
 //!
 use rand::distr::Uniform;
 use rand::prelude::*;
+use rand_distr::Distribution;
 use rand_distr::Normal;
 
 use crate::dataset::Dataset;

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,10 +1,16 @@
 //! # Dataset Generators
 //!
 use rand::distr::Distribution;
+use rand::distr::StandardNormal;
 use rand::distr::Uniform;
-use rand_distr::Normal;
 
 use crate::dataset::Dataset;
+
+/// Sample from N(mean, std) using rand 0.10's StandardNormal
+#[inline]
+fn sample_normal(mean: f32, std: f32, rng: &mut impl rand::Rng) -> f32 {
+    mean + std * StandardNormal.sample(rng)
+}
 
 /// Generate `num_centers` clusters of normally distributed points
 pub fn make_blobs(
@@ -13,26 +19,26 @@ pub fn make_blobs(
     num_centers: usize,
 ) -> Dataset<f32, f32> {
     let center_box = Uniform::new(-10.0f32, 10.0f32).expect("Invalid uniform range");
-    let cluster_std = 1.0;
-    let mut centers: Vec<Vec<Normal<f32>>> = Vec::with_capacity(num_centers);
-
+    let cluster_std = 1.0f32;
     let mut rng = rand::rng();
-    for _ in 0..num_centers {
-        centers.push(
+
+    // Pre-compute cluster centers (mean values per feature)
+    let centers: Vec<Vec<f32>> = (0..num_centers)
+        .map(|_| {
             (0..num_features)
-                .map(|_| Normal::new(center_box.sample(&mut rng), cluster_std).unwrap())
-                .collect(),
-        );
-    }
+                .map(|_| center_box.sample(&mut rng))
+                .collect()
+        })
+        .collect();
 
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
-    let mut x: Vec<f32> = Vec::with_capacity(num_samples);
+    let mut x: Vec<f32> = Vec::with_capacity(num_samples * num_features);
 
     for i in 0..num_samples {
         let label = i % num_centers;
         y.push(label as f32);
         for j in 0..num_features {
-            x.push(centers[label][j].sample(&mut rng));
+            x.push(sample_normal(centers[label][j], cluster_std, &mut rng));
         }
     }
 
@@ -59,21 +65,20 @@ pub fn make_circles(num_samples: usize, factor: f32, noise: f32) -> Dataset<f32,
     let linspace_out = linspace(0.0, 2.0 * std::f32::consts::PI, num_samples_out);
     let linspace_in = linspace(0.0, 2.0 * std::f32::consts::PI, num_samples_in);
 
-    let noise = Normal::new(0.0, noise).unwrap();
     let mut rng = rand::rng();
 
     let mut x: Vec<f32> = Vec::with_capacity(num_samples * 2);
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + noise.sample(&mut rng));
-        x.push(v.sin() + noise.sample(&mut rng));
+        x.push(v.cos() + sample_normal(0.0, noise, &mut rng));
+        x.push(v.sin() + sample_normal(0.0, noise, &mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(v.cos() * factor + noise.sample(&mut rng));
-        x.push(v.sin() * factor + noise.sample(&mut rng));
+        x.push(v.cos() * factor + sample_normal(0.0, noise, &mut rng));
+        x.push(v.sin() * factor + sample_normal(0.0, noise, &mut rng));
         y.push(1.0);
     }
 
@@ -96,21 +101,20 @@ pub fn make_moons(num_samples: usize, noise: f32) -> Dataset<f32, u32> {
     let linspace_out = linspace(0.0, std::f32::consts::PI, num_samples_out);
     let linspace_in = linspace(0.0, std::f32::consts::PI, num_samples_in);
 
-    let noise = Normal::new(0.0, noise).unwrap();
     let mut rng = rand::rng();
 
     let mut x: Vec<f32> = Vec::with_capacity(num_samples * 2);
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
 
     for v in linspace_out {
-        x.push(v.cos() + noise.sample(&mut rng));
-        x.push(v.sin() + noise.sample(&mut rng));
+        x.push(v.cos() + sample_normal(0.0, noise, &mut rng));
+        x.push(v.sin() + sample_normal(0.0, noise, &mut rng));
         y.push(0.0);
     }
 
     for v in linspace_in {
-        x.push(1.0 - v.cos() + noise.sample(&mut rng));
-        x.push(1.0 - v.sin() + noise.sample(&mut rng) - 0.5);
+        x.push(1.0 - v.cos() + sample_normal(0.0, noise, &mut rng));
+        x.push(1.0 - v.sin() + sample_normal(0.0, noise, &mut rng) - 0.5);
         y.push(1.0);
     }
 

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,6 +1,6 @@
 //! # Dataset Generators
 //!
-use rand::distributions::Uniform;
+use rand::distr::Uniform;
 use rand::prelude::*;
 use rand_distr::Normal;
 
@@ -12,11 +12,11 @@ pub fn make_blobs(
     num_features: usize,
     num_centers: usize,
 ) -> Dataset<f32, f32> {
-    let center_box = Uniform::from(-10.0..10.0);
+    let center_box = Uniform::new(-10.0f32, 10.0f32).expect("Invalid uniform range");
     let cluster_std = 1.0;
     let mut centers: Vec<Vec<Normal<f32>>> = Vec::with_capacity(num_centers);
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..num_centers {
         centers.push(
             (0..num_features)
@@ -60,7 +60,7 @@ pub fn make_circles(num_samples: usize, factor: f32, noise: f32) -> Dataset<f32,
     let linspace_in = linspace(0.0, 2.0 * std::f32::consts::PI, num_samples_in);
 
     let noise = Normal::new(0.0, noise).unwrap();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let mut x: Vec<f32> = Vec::with_capacity(num_samples * 2);
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
@@ -97,7 +97,7 @@ pub fn make_moons(num_samples: usize, noise: f32) -> Dataset<f32, u32> {
     let linspace_in = linspace(0.0, std::f32::consts::PI, num_samples_in);
 
     let noise = Normal::new(0.0, noise).unwrap();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let mut x: Vec<f32> = Vec::with_capacity(num_samples * 2);
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);

--- a/src/dataset/generator.rs
+++ b/src/dataset/generator.rs
@@ -1,9 +1,8 @@
 //! # Dataset Generators
 //!
 use rand::distr::Distribution;
-use rand::distr::Normal;
 use rand::distr::Uniform;
-use rand::prelude::*;
+use rand_distr::Normal;
 
 use crate::dataset::Dataset;
 

--- a/src/ensemble/base_forest_regressor.rs
+++ b/src/ensemble/base_forest_regressor.rs
@@ -212,7 +212,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     fn sample_with_replacement(nrows: usize, rng: &mut impl Rng) -> Vec<usize> {
         let mut samples = vec![0; nrows];
         for _ in 0..nrows {
-            let xi = rng.gen_range(0..nrows);
+            let xi = rng.random_range(0..nrows);
             samples[xi] += 1;
         }
         samples

--- a/src/ensemble/base_forest_regressor.rs
+++ b/src/ensemble/base_forest_regressor.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::fmt::Debug;
 
 #[cfg(feature = "serde")]
@@ -209,7 +209,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
         result / TY::from(n_trees).unwrap()
     }
 
-    fn sample_with_replacement(nrows: usize, rng: &mut impl Rng) -> Vec<usize> {
+    fn sample_with_replacement(nrows: usize, rng: &mut impl rand::Rng) -> Vec<usize> {
         let mut samples = vec![0; nrows];
         for _ in 0..nrows {
             let xi = rng.random_range(0..nrows);

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -587,7 +587,11 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
         which_max(&result)
     }
 
-    fn sample_with_replacement(y: &[usize], num_classes: usize, rng: &mut impl rand::Rng) -> Vec<usize> {
+    fn sample_with_replacement(
+        y: &[usize],
+        num_classes: usize,
+        rng: &mut impl rand::Rng,
+    ) -> Vec<usize> {
         let class_weight = vec![1.; num_classes];
         let nrows = y.len();
         let mut samples = vec![0; nrows];

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -45,7 +45,7 @@
 //!
 //! <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 //! <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-use rand::Rng;
+use rand::RngExt;
 
 use std::default::Default;
 use std::fmt::Debug;
@@ -587,7 +587,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
         which_max(&result)
     }
 
-    fn sample_with_replacement(y: &[usize], num_classes: usize, rng: &mut impl Rng) -> Vec<usize> {
+    fn sample_with_replacement(y: &[usize], num_classes: usize, rng: &mut impl rand::Rng) -> Vec<usize> {
         let class_weight = vec![1.; num_classes];
         let nrows = y.len();
         let mut samples = vec![0; nrows];
@@ -603,7 +603,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
 
             let size = ((n_samples as f64) / *class_weight_l) as usize;
             for _ in 0..size {
-                let xi: usize = rng.gen_range(0..n_samples);
+                let xi: usize = rng.random_range(0..n_samples);
                 samples[index[xi]] += 1;
             }
         }

--- a/src/numbers/floatnum.rs
+++ b/src/numbers/floatnum.rs
@@ -56,7 +56,7 @@ impl FloatNumber for f64 {
     }
 
     fn rand() -> f64 {
-        use rand::Rng;
+        use rand::RngExt;
         let mut rng = get_rng_impl(None);
         rng.random()
     }
@@ -98,7 +98,7 @@ impl FloatNumber for f32 {
     }
 
     fn rand() -> f32 {
-        use rand::Rng;
+        use rand::RngExt;
         let mut rng = get_rng_impl(None);
         rng.random()
     }

--- a/src/numbers/floatnum.rs
+++ b/src/numbers/floatnum.rs
@@ -58,7 +58,7 @@ impl FloatNumber for f64 {
     fn rand() -> f64 {
         use rand::Rng;
         let mut rng = get_rng_impl(None);
-        rng.gen()
+        rng.random()
     }
 
     fn two() -> Self {
@@ -100,7 +100,7 @@ impl FloatNumber for f32 {
     fn rand() -> f32 {
         use rand::Rng;
         let mut rng = get_rng_impl(None);
-        rng.gen()
+        rng.random()
     }
 
     fn two() -> Self {

--- a/src/numbers/realnum.rs
+++ b/src/numbers/realnum.rs
@@ -69,10 +69,8 @@ impl RealNumber for f64 {
     fn rand() -> f64 {
         let mut small_rng = get_rng_impl(None);
 
-        let mut rngs: Vec<SmallRng> = (0..3)
-            .map(|_| SmallRng::from_rng(&mut small_rng).unwrap())
-            .collect();
-        rngs[0].gen::<f64>()
+        let mut rngs: Vec<SmallRng> = (0..3).map(|_| SmallRng::from_rng(&mut small_rng)).collect();
+        rngs[0].random::<f64>()
     }
 
     fn two() -> Self {
@@ -118,10 +116,8 @@ impl RealNumber for f32 {
     fn rand() -> f32 {
         let mut small_rng = get_rng_impl(None);
 
-        let mut rngs: Vec<SmallRng> = (0..3)
-            .map(|_| SmallRng::from_rng(&mut small_rng).unwrap())
-            .collect();
-        rngs[0].gen::<f32>()
+        let mut rngs: Vec<SmallRng> = (0..3).map(|_| SmallRng::from_rng(&mut small_rng)).collect();
+        rngs[0].random::<f32>()
     }
 
     fn two() -> Self {

--- a/src/numbers/realnum.rs
+++ b/src/numbers/realnum.rs
@@ -3,7 +3,7 @@
 //! This module defines real number and some useful functions that are used in [Linear Algebra](../../linalg/index.html) module.
 
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 use num_traits::Float;
 

--- a/src/rand_custom.rs
+++ b/src/rand_custom.rs
@@ -12,7 +12,8 @@ pub fn get_rng_impl(seed: Option<u64>) -> RngImpl {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "std_rand")] {
                     use rand::RngCore;
-                    RngImpl::seed_from_u64(rand::thread_rng().next_u64())
+                    // FIX: thread_rng() deprecated in rand 0.9 → use rng()
+                    RngImpl::seed_from_u64(rand::rng().next_u64())
                 } else {
                     // no std_random feature build, use getrandom
                     #[cfg(feature = "js")]

--- a/src/rand_custom.rs
+++ b/src/rand_custom.rs
@@ -11,8 +11,10 @@ pub fn get_rng_impl(seed: Option<u64>) -> RngImpl {
         None => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "std_rand")] {
-                    use rand::RngCore;
+                    use rand::Rng;
                     // FIX: thread_rng() deprecated in rand 0.9 → use rng()
+                    // FIX: rand 0.10 no longer re-exports RngCore at root;
+                    //      import rand::Rng (supertrait) instead so next_u64() resolves
                     RngImpl::seed_from_u64(rand::rng().next_u64())
                 } else {
                     // no std_random feature build, use getrandom

--- a/src/readers/io_testing.rs
+++ b/src/readers/io_testing.rs
@@ -1,7 +1,7 @@
 //! This module contains functionality to test IO. It has both functions that write
 //! to the file-system for end-to-end tests, but also abstractions to avoid this by
 //! reading from strings instead.
-use rand::distributions::{Alphanumeric, DistString};
+use rand::distr::{Alphanumeric, SampleString};
 use std::fs;
 use std::io::Bytes;
 use std::io::Read;
@@ -16,7 +16,7 @@ pub struct TemporaryTextFile {
 impl TemporaryTextFile {
     pub fn new(contents: &str) -> std::io::Result<Self> {
         let test_text_file = TemporaryTextFile {
-            random_path: Alphanumeric.sample_string(&mut rand::thread_rng(), 16),
+            random_path: Alphanumeric.sample_string(&mut rand::rng(), 16),
         };
         string_to_file(contents, &test_text_file.random_path)?;
         Ok(test_text_file)

--- a/src/tree/base_tree_regressor.rs
+++ b/src/tree/base_tree_regressor.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use rand::seq::SliceRandom;
-use rand::Rng;
+use rand::RngExt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -292,7 +292,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         &mut self,
         visitor: &mut NodeVisitor<'_, TX, TY, X, Y>,
         mtry: usize,
-        rng: &mut impl Rng,
+        rng: &mut impl rand::Rng,
     ) -> bool {
         let (_, n_attr) = visitor.x.shape();
 
@@ -336,7 +336,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         sum: f64,
         parent_gain: f64,
         j: usize,
-        rng: &mut impl Rng,
+        rng: &mut impl rand::Rng,
     ) {
         let (min_val, max_val) = {
             let mut min_opt = None;
@@ -363,7 +363,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
             return;
         }
 
-        let split_value = rng.gen_range(min_val.to_f64().unwrap()..max_val.to_f64().unwrap());
+        let split_value = rng.random_range(min_val.to_f64().unwrap()..max_val.to_f64().unwrap());
 
         let mut true_sum = 0f64;
         let mut true_count = 0;
@@ -476,7 +476,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         mut visitor: NodeVisitor<'a, TX, TY, X, Y>,
         mtry: usize,
         visitor_queue: &mut LinkedList<NodeVisitor<'a, TX, TY, X, Y>>,
-        rng: &mut impl Rng,
+        rng: &mut impl rand::Rng,
     ) -> bool {
         let (n, _) = visitor.x.shape();
         let mut tc = 0;


### PR DESCRIPTION
- Update rand 0.8.5 → 0.10.1
- Update rand_distr 0.4 → 0.5
- Update getrandom 0.2.8 → 0.3
- Add rand/thread_rng to std_rand feature (required in 0.9+)
- Rename getrandom/js feature → getrandom/wasm_js (getrandom 0.3)
- Replace deprecated thread_rng() → rng() (rand_custom, generator, io_testing)
- Replace deprecated gen() → random() (floatnum, realnum, kmeans)
- Replace deprecated gen_range() → random_range() (kmeans, base_forest_regressor, random_forest_classifier, base_tree_regressor)
- Replace distributions:: → distr:: module path (generator, io_testing)
- Replace DistString → SampleString trait (io_testing)
- Replace Uniform::from(range) → Uniform::new(a, b) (generator)
- Remove infallible .unwrap() from SmallRng::from_rng() (realnum)

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #365 

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied 
