### PR TITLE
Fix ROC AUC computation for tied prediction scores

### DIFF
--- a/src/metrics/auc.rs
+++ b/src/metrics/auc.rs
@@ -80,11 +80,11 @@ impl<T: FloatNumber + PartialOrd> Metrics<T> for AUC<T> {
         let mut rank = vec![0f64; n];
         let mut i = 0;
         while i < n {
-            if i == n - 1 || y_pred.get(i) != y_pred.get(i + 1) {
+            if i == n - 1 || y_pred.get(label_idx[i]) != y_pred.get(label_idx[i + 1]) {
                 rank[i] = (i + 1) as f64;
             } else {
                 let mut j = i + 1;
-                while j < n && y_pred.get(j) == y_pred.get(i) {
+                while j < n && y_pred.get(label_idx[j]) == y_pred.get(label_idx[i]) {
                     j += 1;
                 }
                 let r = (i + 1 + j) as f64 / 2f64;
@@ -127,5 +127,20 @@ mod tests {
 
         assert!((score1 - 0.75).abs() < 1e-8);
         assert!((score2 - 1.0).abs() < 1e-8);
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn auc_tied_scores() {
+        // Two samples share score 0.5 but are non-adjacent in input order.
+        // Pairwise ROC AUC (ties credited 0.5): pos {0.9,0.5} vs neg {0.5}
+        //   -> (1.0 + 0.5) / 2 = 0.75  (matches sklearn roc_auc_score)
+        let y_true: Vec<f64> = vec![0., 1., 1.];
+        let y_pred: Vec<f64> = vec![0.5, 0.9, 0.5];
+        let score: f64 = AUC::new().get_score(&y_true, &y_pred);
+        assert!((score - 0.75).abs() < 1e-8);
     }
 }


### PR DESCRIPTION
Fixes #373

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied

### Current behaviour
`metrics::auc::AUC::get_score` (the Mann-Whitney/Wilcoxon rank-sum ROC AUC) mis-handles tied prediction scores. Ties are only rank-averaged when the equal scores happen to be adjacent in the input array; when equal scores are non-adjacent in the input they get distinct ranks, yielding a wrong AUC.

`get_score` builds `label_idx = y_pred.argsort()` and assigns ranks by sorted position, later pairing `rank[i]` with `label_idx[i]`. The tie-detection loop, however, compared scores in the *original* input order:

```rust
if i == n - 1 || y_pred.get(i) != y_pred.get(i + 1) { ... }
```

`argsort()` returns an index permutation and does not reorder `y_pred`, so `y_pred.get(i)` reads unsorted input while `rank[i]` corresponds to the `i`-th smallest score. Tied scores therefore only get the averaged rank when they are already adjacent in the input; otherwise they receive `i + 1` instead of the averaged value and the AUC is wrong.

Concrete reproducer (`y_true = [0, 1, 1]`, `y_pred = [0.5, 0.9, 0.5]`): the two positives score `{0.9, 0.5}` versus the negative's `{0.5}`, so pairwise ROC AUC crediting ties 0.5 is `(1.0 + 0.5) / 2 = 0.75` (matches `sklearn.metrics.roc_auc_score`). Before this change the function returns `1.0`.

### New expected behaviour
The tie-detection compares scores in sorted order via `label_idx`, so equal scores are always grouped and rank-averaged regardless of their input position. `label_idx[i + 1]` is only read when `i != n - 1`, so there is no out-of-bounds access. The reproducer now returns `0.75`.

Testing:
- Added `auc_tied_scores`, a regression test using two tied, non-adjacent scores. It fails on the current code (returns 1.0) and passes with the fix (0.75).
- The existing `auc` test still passes (its tie group is already sorted-adjacent, so ranks are unchanged).
- `cargo test --lib metrics::auc` — 2 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-features -- -Drust-2018-idioms -Dwarnings` — clean.

### Change logs
Non-breaking bug fix (no interface change), so no CHANGELOG entry per the contributing guidelines (which ask to update CHANGELOG.md for breaking interface changes).
