### PR TITLE
Add getter for parameters in all model structs.

### DIFF
--- a/src/cluster/agglomerative.rs
+++ b/src/cluster/agglomerative.rs
@@ -188,10 +188,9 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> AgglomerativeClusteri
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &AgglomerativeClusteringParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&AgglomerativeClusteringParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -324,5 +323,36 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 5.0, 5.0, 10.0, 10.0];
+        let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
+        let parameters = AgglomerativeClusteringParameters::default().with_n_clusters(1);
+        let expected_parameters = parameters.clone();
+        let clustering = AgglomerativeClustering::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix, parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = clustering
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.n_clusters, expected_parameters.n_clusters);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let clustering = AgglomerativeClustering::<f64, f64, DenseMatrix<f64>, Vec<f64>> {
+            labels: Vec::new(),
+            parameters: None,
+            _phantom_tx: PhantomData,
+            _phantom_ty: PhantomData,
+            _phantom_x: PhantomData,
+            _phantom_y: PhantomData,
+        };
+
+        assert!(clustering.parameters().is_none());
     }
 }

--- a/src/cluster/agglomerative.rs
+++ b/src/cluster/agglomerative.rs
@@ -76,6 +76,7 @@ impl Default for AgglomerativeClusteringParameters {
 pub struct AgglomerativeClustering<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> {
     /// The cluster label assigned to each sample.
     pub labels: Vec<usize>,
+    parameters: Option<AgglomerativeClusteringParameters>,
     _phantom_tx: PhantomData<TX>,
     _phantom_ty: PhantomData<TY>,
     _phantom_x: PhantomData<X>,
@@ -176,11 +177,21 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> AgglomerativeClusteri
         }
         Ok(AgglomerativeClustering {
             labels,
+            parameters: Some(parameters),
             _phantom_tx: PhantomData,
             _phantom_ty: PhantomData,
             _phantom_x: PhantomData,
             _phantom_y: PhantomData,
         })
+    }
+
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &AgglomerativeClusteringParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -431,7 +431,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
 
         Ok(result)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -557,7 +557,10 @@ mod tests {
             format!("{:?}", actual_parameters.distance),
             format!("{:?}", expected_parameters.distance)
         );
-        assert_eq!(actual_parameters.min_samples, expected_parameters.min_samples);
+        assert_eq!(
+            actual_parameters.min_samples,
+            expected_parameters.min_samples
+        );
         assert_eq!(actual_parameters.eps, expected_parameters.eps);
         assert_eq!(
             std::mem::discriminant(&actual_parameters.algorithm),
@@ -580,20 +583,19 @@ mod tests {
 
         println!("{labels:?}");
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.5, 0.5, 10.0, 10.0];
         let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
-        let parameters: DBSCANParameters<f64, Euclidian<f64>> =
-            DBSCANParameters::default().with_eps(1.0).with_min_samples(1);
+        let parameters: DBSCANParameters<f64, Euclidian<f64>> = DBSCANParameters::default()
+            .with_eps(1.0)
+            .with_min_samples(1);
         let expected_parameters = parameters.clone();
-        let clustering =
-            DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
-                &matrix,
-                parameters,
-            )
-            .unwrap();
+        let clustering = DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+            &matrix, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = clustering
             .parameters()
@@ -602,7 +604,10 @@ mod tests {
             format!("{:?}", actual_parameters.distance),
             format!("{:?}", expected_parameters.distance)
         );
-        assert_eq!(actual_parameters.min_samples, expected_parameters.min_samples);
+        assert_eq!(
+            actual_parameters.min_samples,
+            expected_parameters.min_samples
+        );
         assert_eq!(actual_parameters.eps, expected_parameters.eps);
         assert_eq!(
             std::mem::discriminant(&actual_parameters.algorithm),
@@ -614,14 +619,13 @@ mod tests {
     fn test_returns_none_on_no_parameters() {
         let data = vec![0.0, 0.0, 0.5, 0.5, 10.0, 10.0];
         let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
-        let parameters: DBSCANParameters<f64, Euclidian<f64>> =
-            DBSCANParameters::default().with_eps(1.0).with_min_samples(1);
-        let mut clustering =
-            DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
-                &matrix,
-                parameters,
-            )
-            .unwrap();
+        let parameters: DBSCANParameters<f64, Euclidian<f64>> = DBSCANParameters::default()
+            .with_eps(1.0)
+            .with_min_samples(1);
+        let mut clustering = DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+            &matrix, parameters,
+        )
+        .unwrap();
         clustering.parameters = None;
 
         assert!(clustering.parameters().is_none());

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -64,6 +64,7 @@ pub struct DBSCAN<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Dista
     num_classes: usize,
     knn_algorithm: KNNAlgorithm<TX, D>,
     eps: f64,
+    parameters: Option<DBSCANParameters<TX, D>>,
     _phantom_ty: PhantomData<TY>,
     _phantom_x: PhantomData<X>,
     _phantom_y: PhantomData<Y>,
@@ -295,7 +296,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
             x.row_iter()
                 .map(|row| row.iterator(0).cloned().collect())
                 .collect(),
-            parameters.distance,
+            parameters.distance.clone(),
         )?;
 
         let mut row = vec![TX::zero(); x.shape().1];
@@ -353,6 +354,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
             num_classes: k as usize,
             knn_algorithm: algo,
             eps: parameters.eps,
+            parameters: Some(parameters),
             _phantom_ty: PhantomData,
             _phantom_x: PhantomData,
             _phantom_y: PhantomData,
@@ -391,6 +393,15 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
         }
 
         Ok(result)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &DBSCANParameters<TX, D> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -398,10 +398,9 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &DBSCANParameters<TX, D> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&DBSCANParameters<TX, D>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -524,5 +523,51 @@ mod tests {
             .unwrap();
 
         println!("{labels:?}");
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.5, 0.5, 10.0, 10.0];
+        let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
+        let parameters: DBSCANParameters<f64, Euclidian<f64>> =
+            DBSCANParameters::default().with_eps(1.0).with_min_samples(1);
+        let expected_parameters = parameters.clone();
+        let clustering =
+            DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+                &matrix,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = clustering
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(actual_parameters.min_samples, expected_parameters.min_samples);
+        assert_eq!(actual_parameters.eps, expected_parameters.eps);
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.5, 0.5, 10.0, 10.0];
+        let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
+        let parameters: DBSCANParameters<f64, Euclidian<f64>> =
+            DBSCANParameters::default().with_eps(1.0).with_min_samples(1);
+        let mut clustering =
+            DBSCAN::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+                &matrix,
+                parameters,
+            )
+            .unwrap();
+        clustering.parameters = None;
+
+        assert!(clustering.parameters().is_none());
     }
 }

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -92,8 +92,8 @@ pub struct DBSCANParameters<T: Number, D: Distance<Vec<T>>> {
     _phantom_t: PhantomData<T>,
 }
 
-// A manual implementation avoids adding an unnecessary `Default` bound to
-// generic parameter types while preserving their serialized representation.
+// SERDE: a manual implementation avoids the implicit `Default` bounds that
+// `#[derive(Deserialize)]` would add to generic parameter types.
 #[cfg(feature = "serde")]
 impl<'de, T, D> Deserialize<'de> for DBSCANParameters<T, D>
 where

--- a/src/cluster/dbscan.rs
+++ b/src/cluster/dbscan.rs
@@ -70,7 +70,7 @@ pub struct DBSCAN<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Dista
     _phantom_y: PhantomData<Y>,
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone)]
 /// DBSCAN clustering algorithm parameters
 pub struct DBSCANParameters<T: Number, D: Distance<Vec<T>>> {
@@ -90,6 +90,43 @@ pub struct DBSCANParameters<T: Number, D: Distance<Vec<T>>> {
     pub algorithm: KNNAlgorithmName,
     #[cfg_attr(feature = "serde", serde(default))]
     _phantom_t: PhantomData<T>,
+}
+
+// A manual implementation avoids adding an unnecessary `Default` bound to
+// generic parameter types while preserving their serialized representation.
+#[cfg(feature = "serde")]
+impl<'de, T, D> Deserialize<'de> for DBSCANParameters<T, D>
+where
+    T: Number,
+    D: Distance<Vec<T>> + Deserialize<'de>,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct DBSCANParametersData<D> {
+            distance: D,
+            #[serde(default)]
+            min_samples: usize,
+            #[serde(default)]
+            eps: f64,
+            #[serde(default)]
+            algorithm: KNNAlgorithmName,
+            #[serde(default)]
+            _phantom_t: PhantomData<()>,
+        }
+
+        let data = DBSCANParametersData::deserialize(deserializer)?;
+
+        Ok(Self {
+            distance: data.distance,
+            min_samples: data.min_samples,
+            eps: data.eps,
+            algorithm: data.algorithm,
+            _phantom_t: PhantomData,
+        })
+    }
 }
 
 impl<T: Number, D: Distance<Vec<T>>> DBSCANParameters<T, D> {
@@ -501,12 +538,31 @@ mod tests {
         ])
         .unwrap();
 
-        let dbscan = DBSCAN::fit(&x, Default::default()).unwrap();
+        let parameters = DBSCANParameters::default()
+            .with_eps(0.5)
+            .with_min_samples(2)
+            .with_algorithm(KNNAlgorithmName::LinearSearch);
+        let expected_parameters = parameters.clone();
+        let dbscan = DBSCAN::fit(&x, parameters).unwrap();
 
         let deserialized_dbscan: DBSCAN<f32, f32, DenseMatrix<f32>, Vec<f32>, Euclidian<f32>> =
             serde_json::from_str(&serde_json::to_string(&dbscan).unwrap()).unwrap();
 
         assert_eq!(dbscan, deserialized_dbscan);
+
+        let actual_parameters = deserialized_dbscan
+            .parameters()
+            .expect("parameters should survive serialization");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(actual_parameters.min_samples, expected_parameters.min_samples);
+        assert_eq!(actual_parameters.eps, expected_parameters.eps);
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
     }
 
     #[cfg(feature = "datasets")]

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -413,7 +413,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
 
         y
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -553,18 +553,15 @@ mod tests {
 
         assert_eq!(kmeans, deserialized_kmeans);
     }
- 
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 5.0, 5.0, 10.0, 10.0];
         let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
         let parameters = KMeansParameters::default().with_k(2);
         let expected_parameters = parameters.clone();
-        let clustering = KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            parameters,
-        )
-        .unwrap();
+        let clustering =
+            KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, parameters).unwrap();
 
         let actual_parameters = clustering
             .parameters()
@@ -579,11 +576,8 @@ mod tests {
         let data = vec![0.0, 0.0, 5.0, 5.0, 10.0, 10.0];
         let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
         let parameters = KMeansParameters::default().with_k(2);
-        let mut clustering = KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            parameters,
-        )
-        .unwrap();
+        let mut clustering =
+            KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, parameters).unwrap();
         clustering.parameters = None;
 
         assert!(clustering.parameters().is_none());

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -417,10 +417,9 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &KMeansParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&KMeansParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -553,5 +552,40 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&kmeans).unwrap()).unwrap();
 
         assert_eq!(kmeans, deserialized_kmeans);
+    }
+ 
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 5.0, 5.0, 10.0, 10.0];
+        let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
+        let parameters = KMeansParameters::default().with_k(2);
+        let expected_parameters = parameters.clone();
+        let clustering = KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = clustering
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.k, expected_parameters.k);
+        assert_eq!(actual_parameters.max_iter, expected_parameters.max_iter);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 5.0, 5.0, 10.0, 10.0];
+        let matrix = DenseMatrix::new(3, 2, data, false).unwrap();
+        let parameters = KMeansParameters::default().with_k(2);
+        let mut clustering = KMeans::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            parameters,
+        )
+        .unwrap();
+        clustering.parameters = None;
+
+        assert!(clustering.parameters().is_none());
     }
 }

--- a/src/cluster/kmeans.rs
+++ b/src/cluster/kmeans.rs
@@ -76,6 +76,7 @@ pub struct KMeans<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> {
     size: Vec<usize>,
     _distortion: f64,
     centroids: Vec<Vec<f64>>,
+    parameters: Option<KMeansParameters>,
     _phantom_tx: PhantomData<TX>,
     _phantom_ty: PhantomData<TY>,
     _phantom_x: PhantomData<X>,
@@ -315,6 +316,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
             size,
             _distortion: distortion,
             centroids,
+            parameters: Some(parameters),
             _phantom_tx: PhantomData,
             _phantom_ty: PhantomData,
             _phantom_x: PhantomData,
@@ -410,6 +412,15 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>> KMeans<TX, TY, X, Y> 
         }
 
         y
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &KMeansParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -362,7 +362,7 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
     pub fn components(&self) -> &X {
         &self.projection
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -757,7 +757,7 @@ mod tests {
 
     //     assert_eq!(pca, deserialized_pca);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -769,7 +769,10 @@ mod tests {
         let actual_parameters = pca
             .parameters()
             .expect("parameters should be set after fitting");
-        assert_eq!(actual_parameters.n_components, expected_parameters.n_components);
+        assert_eq!(
+            actual_parameters.n_components,
+            expected_parameters.n_components
+        );
         assert_eq!(
             actual_parameters.use_correlation_matrix,
             expected_parameters.use_correlation_matrix

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -65,6 +65,7 @@ pub struct PCA<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDe
     eigenvectors: X,
     eigenvalues: Vec<T>,
     projection: X,
+    parameters: Option<PCAParameters>,
     mu: Vec<T>,
     pmu: Vec<T>,
 }
@@ -329,6 +330,7 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
             eigenvectors,
             eigenvalues,
             projection: projection.transpose(),
+            parameters: Some(parameters),
             mu,
             pmu,
         })
@@ -359,6 +361,15 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
     /// Get a projection matrix
     pub fn components(&self) -> &X {
         &self.projection
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &PCAParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/decomposition/pca.rs
+++ b/src/decomposition/pca.rs
@@ -366,10 +366,9 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &PCAParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&PCAParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -758,4 +757,33 @@ mod tests {
 
     //     assert_eq!(pca, deserialized_pca);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let parameters = PCAParameters::default().with_n_components(1);
+        let expected_parameters = parameters.clone();
+        let pca = PCA::<f64, DenseMatrix<f64>>::fit(&matrix, parameters).unwrap();
+
+        let actual_parameters = pca
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.n_components, expected_parameters.n_components);
+        assert_eq!(
+            actual_parameters.use_correlation_matrix,
+            expected_parameters.use_correlation_matrix
+        );
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let parameters = PCAParameters::default().with_n_components(1);
+        let mut pca = PCA::<f64, DenseMatrix<f64>>::fit(&matrix, parameters).unwrap();
+        pca.parameters = None;
+
+        assert!(pca.parameters().is_none());
+    }
 }

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -218,10 +218,9 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &SVDParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&SVDParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -363,4 +362,29 @@ mod tests {
 
     //     assert_eq!(svd, deserialized_svd);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let matrix = DenseMatrix::new(3, 3, data, false).unwrap();
+        let parameters = SVDParameters::default().with_n_components(1);
+        let expected_parameters = parameters.clone();
+        let svd = SVD::<f64, DenseMatrix<f64>>::fit(&matrix, parameters).unwrap();
+
+        let actual_parameters = svd
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.n_components, expected_parameters.n_components);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let matrix = DenseMatrix::new(3, 3, data, false).unwrap();
+        let parameters = SVDParameters::default().with_n_components(1);
+        let mut svd = SVD::<f64, DenseMatrix<f64>>::fit(&matrix, parameters).unwrap();
+        svd.parameters = None;
+
+        assert!(svd.parameters().is_none());
+    }
 }

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -62,6 +62,7 @@ use crate::numbers::realnum::RealNumber;
 #[derive(Debug)]
 pub struct SVD<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable<T>> {
     components: X,
+    parameters: Option<SVDParameters>,
     phantom: PhantomData<T>,
 }
 
@@ -190,6 +191,7 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
 
         Ok(SVD {
             components,
+            parameters: Some(parameters),
             phantom: PhantomData,
         })
     }
@@ -211,6 +213,15 @@ impl<T: Number + RealNumber, X: Array2<T> + SVDDecomposable<T> + EVDDecomposable
     /// Get a projection matrix
     pub fn components(&self) -> &X {
         &self.components
+    }
+
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &SVDParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/decomposition/svd.rs
+++ b/src/decomposition/svd.rs
@@ -362,7 +362,7 @@ mod tests {
 
     //     assert_eq!(svd, deserialized_svd);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
@@ -374,7 +374,10 @@ mod tests {
         let actual_parameters = svd
             .parameters()
             .expect("parameters should be set after fitting");
-        assert_eq!(actual_parameters.n_components, expected_parameters.n_components);
+        assert_eq!(
+            actual_parameters.n_components,
+            expected_parameters.n_components
+        );
     }
 
     #[test]

--- a/src/ensemble/extra_trees_regressor.rs
+++ b/src/ensemble/extra_trees_regressor.rs
@@ -229,10 +229,9 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &ExtraTreesRegressorParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&ExtraTreesRegressorParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -326,5 +325,50 @@ mod tests {
         let y_hat2 = regressor2.predict(&x).unwrap();
 
         assert_eq!(y_hat1, y_hat2);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = ExtraTreesRegressorParameters::default();
+        let expected_parameters = parameters.clone();
+        let regressor =
+            ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
+        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
+        assert_eq!(actual_parameters.m, expected_parameters.m);
+        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = ExtraTreesRegressorParameters::default();
+        let mut regressor =
+            ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }

--- a/src/ensemble/extra_trees_regressor.rs
+++ b/src/ensemble/extra_trees_regressor.rs
@@ -104,6 +104,7 @@ pub struct ExtraTreesRegressor<
     Y: Array1<TY>,
 > {
     forest_regressor: Option<BaseForestRegressor<TX, TY, X, Y>>,
+    parameters: Option<ExtraTreesRegressorParameters>
 }
 
 impl ExtraTreesRegressorParameters {
@@ -165,6 +166,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     fn new() -> Self {
         Self {
             forest_regressor: Option::None,
+            parameters: Option::None
         }
     }
 
@@ -207,6 +209,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
 
         Ok(ExtraTreesRegressor {
             forest_regressor: Some(forest_regressor),
+            parameters: Some(parameters)
         })
     }
 
@@ -221,6 +224,15 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     pub fn predict_oob(&self, x: &X) -> Result<Y, Failed> {
         let forest_regressor = self.forest_regressor.as_ref().unwrap();
         forest_regressor.predict_oob(x)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &ExtraTreesRegressorParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/ensemble/extra_trees_regressor.rs
+++ b/src/ensemble/extra_trees_regressor.rs
@@ -104,7 +104,7 @@ pub struct ExtraTreesRegressor<
     Y: Array1<TY>,
 > {
     forest_regressor: Option<BaseForestRegressor<TX, TY, X, Y>>,
-    parameters: Option<ExtraTreesRegressorParameters>
+    parameters: Option<ExtraTreesRegressorParameters>,
 }
 
 impl ExtraTreesRegressorParameters {
@@ -166,7 +166,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     fn new() -> Self {
         Self {
             forest_regressor: Option::None,
-            parameters: Option::None
+            parameters: Option::None,
         }
     }
 
@@ -209,7 +209,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
 
         Ok(ExtraTreesRegressor {
             forest_regressor: Some(forest_regressor),
-            parameters: Some(parameters)
+            parameters: Some(parameters),
         })
     }
 
@@ -225,7 +225,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
         let forest_regressor = self.forest_regressor.as_ref().unwrap();
         forest_regressor.predict_oob(x)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -326,7 +326,7 @@ mod tests {
 
         assert_eq!(y_hat1, y_hat2);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -334,23 +334,29 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = ExtraTreesRegressorParameters::default();
         let expected_parameters = parameters.clone();
-        let regressor =
-            ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let regressor = ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = regressor
             .parameters()
             .expect("parameters should be set after fitting");
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
-        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(
+            actual_parameters.min_samples_leaf,
+            expected_parameters.min_samples_leaf
+        );
+        assert_eq!(
+            actual_parameters.min_samples_split,
+            expected_parameters.min_samples_split
+        );
         assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
         assert_eq!(actual_parameters.m, expected_parameters.m);
-        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(
+            actual_parameters.keep_samples,
+            expected_parameters.keep_samples
+        );
         assert_eq!(actual_parameters.seed, expected_parameters.seed);
     }
 
@@ -360,13 +366,10 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = ExtraTreesRegressorParameters::default();
-        let mut regressor =
-            ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let mut regressor = ExtraTreesRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
         regressor.parameters = None;
 
         assert!(regressor.parameters().is_none());

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -107,7 +107,7 @@ pub struct RandomForestClassifier<
     trees: Option<Vec<DecisionTreeClassifier<TX, TY, X, Y>>>,
     classes: Option<Vec<TY>>,
     samples: Option<Vec<Vec<bool>>>,
-    parameters: Option<RandomForestClassifierParameters>
+    parameters: Option<RandomForestClassifierParameters>,
 }
 
 impl RandomForestClassifierParameters {
@@ -508,7 +508,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
             trees: Some(trees),
             classes: Some(classes),
             samples: maybe_all_samples,
-            parameters: Some(parameters)
+            parameters: Some(parameters),
         })
     }
 
@@ -616,7 +616,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
         }
         samples
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -821,7 +821,7 @@ mod tests {
 
         assert_eq!(forest, deserialized_forest);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -829,13 +829,10 @@ mod tests {
         let target = vec![0, 0, 1, 1];
         let parameters = RandomForestClassifierParameters::default();
         let expected_parameters = parameters.clone();
-        let classifier =
-            RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let classifier = RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = classifier
             .parameters()
@@ -845,11 +842,20 @@ mod tests {
             std::mem::discriminant(&expected_parameters.criterion)
         );
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
-        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(
+            actual_parameters.min_samples_leaf,
+            expected_parameters.min_samples_leaf
+        );
+        assert_eq!(
+            actual_parameters.min_samples_split,
+            expected_parameters.min_samples_split
+        );
         assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
         assert_eq!(actual_parameters.m, expected_parameters.m);
-        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(
+            actual_parameters.keep_samples,
+            expected_parameters.keep_samples
+        );
         assert_eq!(actual_parameters.seed, expected_parameters.seed);
     }
 
@@ -859,13 +865,10 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0, 0, 1, 1];
         let parameters = RandomForestClassifierParameters::default();
-        let mut classifier =
-            RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let mut classifier = RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
         classifier.parameters = None;
 
         assert!(classifier.parameters().is_none());

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -620,10 +620,9 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &RandomForestClassifierParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&RandomForestClassifierParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -821,5 +820,54 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&forest).unwrap()).unwrap();
 
         assert_eq!(forest, deserialized_forest);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters = RandomForestClassifierParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier =
+            RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.criterion),
+            std::mem::discriminant(&expected_parameters.criterion)
+        );
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
+        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
+        assert_eq!(actual_parameters.m, expected_parameters.m);
+        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters = RandomForestClassifierParameters::default();
+        let mut classifier =
+            RandomForestClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -107,6 +107,7 @@ pub struct RandomForestClassifier<
     trees: Option<Vec<DecisionTreeClassifier<TX, TY, X, Y>>>,
     classes: Option<Vec<TY>>,
     samples: Option<Vec<Vec<bool>>>,
+    parameters: Option<RandomForestClassifierParameters>
 }
 
 impl RandomForestClassifierParameters {
@@ -200,6 +201,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: 
             trees: Option::None,
             classes: Option::None,
             samples: Option::None,
+            parameters: Option::None,
         }
     }
     fn fit(x: &X, y: &Y, parameters: RandomForestClassifierParameters) -> Result<Self, Failed> {
@@ -506,6 +508,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
             trees: Some(trees),
             classes: Some(classes),
             samples: maybe_all_samples,
+            parameters: Some(parameters)
         })
     }
 
@@ -612,6 +615,15 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
             }
         }
         samples
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &RandomForestClassifierParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -95,6 +95,7 @@ pub struct RandomForestRegressor<
     Y: Array1<TY>,
 > {
     forest_regressor: Option<BaseForestRegressor<TX, TY, X, Y>>,
+    parameters: Option<RandomForestRegressorParameters>
 }
 
 impl RandomForestRegressorParameters {
@@ -165,6 +166,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     fn new() -> Self {
         Self {
             forest_regressor: Option::None,
+            parameters: Option::None,
         }
     }
 
@@ -399,6 +401,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
 
         Ok(RandomForestRegressor {
             forest_regressor: Some(forest_regressor),
+            parameters: Some(parameters)
         })
     }
 
@@ -413,6 +416,15 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     pub fn predict_oob(&self, x: &X) -> Result<Y, Failed> {
         let forest_regressor = self.forest_regressor.as_ref().unwrap();
         forest_regressor.predict_oob(x)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &RandomForestRegressorParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -95,7 +95,7 @@ pub struct RandomForestRegressor<
     Y: Array1<TY>,
 > {
     forest_regressor: Option<BaseForestRegressor<TX, TY, X, Y>>,
-    parameters: Option<RandomForestRegressorParameters>
+    parameters: Option<RandomForestRegressorParameters>,
 }
 
 impl RandomForestRegressorParameters {
@@ -401,7 +401,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
 
         Ok(RandomForestRegressor {
             forest_regressor: Some(forest_regressor),
-            parameters: Some(parameters)
+            parameters: Some(parameters),
         })
     }
 
@@ -417,7 +417,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
         let forest_regressor = self.forest_regressor.as_ref().unwrap();
         forest_regressor.predict_oob(x)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -623,7 +623,7 @@ mod tests {
 
         assert_eq!(forest, deserialized_forest);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -631,23 +631,29 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = RandomForestRegressorParameters::default();
         let expected_parameters = parameters.clone();
-        let regressor =
-            RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let regressor = RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = regressor
             .parameters()
             .expect("parameters should be set after fitting");
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
-        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(
+            actual_parameters.min_samples_leaf,
+            expected_parameters.min_samples_leaf
+        );
+        assert_eq!(
+            actual_parameters.min_samples_split,
+            expected_parameters.min_samples_split
+        );
         assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
         assert_eq!(actual_parameters.m, expected_parameters.m);
-        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(
+            actual_parameters.keep_samples,
+            expected_parameters.keep_samples
+        );
         assert_eq!(actual_parameters.seed, expected_parameters.seed);
     }
 
@@ -657,13 +663,10 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = RandomForestRegressorParameters::default();
-        let mut regressor =
-            RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let mut regressor = RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
         regressor.parameters = None;
 
         assert!(regressor.parameters().is_none());

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -421,10 +421,9 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &RandomForestRegressorParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&RandomForestRegressorParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -623,5 +622,50 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&forest).unwrap()).unwrap();
 
         assert_eq!(forest, deserialized_forest);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = RandomForestRegressorParameters::default();
+        let expected_parameters = parameters.clone();
+        let regressor =
+            RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
+        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(actual_parameters.n_trees, expected_parameters.n_trees);
+        assert_eq!(actual_parameters.m, expected_parameters.m);
+        assert_eq!(actual_parameters.keep_samples, expected_parameters.keep_samples);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = RandomForestRegressorParameters::default();
+        let mut regressor =
+            RandomForestRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }

--- a/src/linear/elastic_net.rs
+++ b/src/linear/elastic_net.rs
@@ -462,7 +462,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
         (x2, y2, gamma)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -656,7 +656,7 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -664,12 +664,9 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = ElasticNetParameters::default();
         let expected_parameters = parameters.clone();
-        let regression = ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let regression =
+            ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = regression
             .parameters()
@@ -687,12 +684,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = ElasticNetParameters::default();
-        let mut regression = ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut regression =
+            ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
         regression.parameters = None;
 
         assert!(regression.parameters().is_none());

--- a/src/linear/elastic_net.rs
+++ b/src/linear/elastic_net.rs
@@ -466,10 +466,9 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &ElasticNetParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&ElasticNetParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -657,4 +656,45 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = ElasticNetParameters::default();
+        let expected_parameters = parameters.clone();
+        let regression = ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regression
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.alpha, expected_parameters.alpha);
+        assert_eq!(actual_parameters.l1_ratio, expected_parameters.l1_ratio);
+        assert_eq!(actual_parameters.normalize, expected_parameters.normalize);
+        assert_eq!(actual_parameters.tol, expected_parameters.tol);
+        assert_eq!(actual_parameters.max_iter, expected_parameters.max_iter);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = ElasticNetParameters::default();
+        let mut regression = ElasticNet::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regression.parameters = None;
+
+        assert!(regression.parameters().is_none());
+    }
 }

--- a/src/linear/elastic_net.rs
+++ b/src/linear/elastic_net.rs
@@ -98,6 +98,7 @@ pub struct ElasticNetParameters {
 pub struct ElasticNet<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> {
     coefficients: Option<X>,
     intercept: Option<TX>,
+    parameters: Option<ElasticNetParameters>,
     _phantom_ty: PhantomData<TY>,
     _phantom_y: PhantomData<Y>,
 }
@@ -288,6 +289,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         Self {
             coefficients: Option::None,
             intercept: Option::None,
+            parameters: Option::None,
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         }
@@ -385,6 +387,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         Ok(ElasticNet {
             intercept: Some(b),
             coefficients: Some(w),
+            parameters: Some(parameters),
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         })
@@ -458,6 +461,15 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         }
 
         (x2, y2, gamma)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &ElasticNetParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/linear/lasso.rs
+++ b/src/linear/lasso.rs
@@ -405,7 +405,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> Las
         scaled_x.scale_mut(&col_mean, &col_std, 0);
         Ok((scaled_x, col_mean, col_std))
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -585,7 +585,7 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -593,12 +593,9 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = LassoParameters::default();
         let expected_parameters = parameters.clone();
-        let regression = Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let regression =
+            Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = regression
             .parameters()
@@ -607,7 +604,10 @@ mod tests {
         assert_eq!(actual_parameters.normalize, expected_parameters.normalize);
         assert_eq!(actual_parameters.tol, expected_parameters.tol);
         assert_eq!(actual_parameters.max_iter, expected_parameters.max_iter);
-        assert_eq!(actual_parameters.fit_intercept, expected_parameters.fit_intercept);
+        assert_eq!(
+            actual_parameters.fit_intercept,
+            expected_parameters.fit_intercept
+        );
     }
 
     #[test]
@@ -616,12 +616,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = LassoParameters::default();
-        let mut regression = Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut regression =
+            Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
         regression.parameters = None;
 
         assert!(regression.parameters().is_none());

--- a/src/linear/lasso.rs
+++ b/src/linear/lasso.rs
@@ -409,10 +409,9 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> Las
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &LassoParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&LassoParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -586,4 +585,45 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = LassoParameters::default();
+        let expected_parameters = parameters.clone();
+        let regression = Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regression
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.alpha, expected_parameters.alpha);
+        assert_eq!(actual_parameters.normalize, expected_parameters.normalize);
+        assert_eq!(actual_parameters.tol, expected_parameters.tol);
+        assert_eq!(actual_parameters.max_iter, expected_parameters.max_iter);
+        assert_eq!(actual_parameters.fit_intercept, expected_parameters.fit_intercept);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = LassoParameters::default();
+        let mut regression = Lasso::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regression.parameters = None;
+
+        assert!(regression.parameters().is_none());
+    }
 }

--- a/src/linear/lasso.rs
+++ b/src/linear/lasso.rs
@@ -64,6 +64,7 @@ pub struct LassoParameters {
 pub struct Lasso<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> {
     coefficients: Option<X>,
     intercept: Option<TX>,
+    parameters: Option<LassoParameters>,
     _phantom_ty: PhantomData<TY>,
     _phantom_y: PhantomData<Y>,
 }
@@ -130,6 +131,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         Self {
             coefficients: None,
             intercept: None,
+            parameters: None,
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         }
@@ -352,6 +354,7 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> Las
         Ok(Lasso {
             intercept: b,
             coefficients: Some(w),
+            parameters: Some(parameters),
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         })
@@ -401,6 +404,15 @@ impl<TX: FloatNumber + RealNumber, TY: Number, X: Array2<TX>, Y: Array1<TY>> Las
         let mut scaled_x = x.clone();
         scaled_x.scale_mut(&col_mean, &col_std, 0);
         Ok((scaled_x, col_mean, col_std))
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &LassoParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -113,6 +113,7 @@ pub struct LinearRegression<
 > {
     coefficients: Option<X>,
     intercept: Option<TX>,
+    parameters: Option<LinearRegressionParameters>,
     _phantom_ty: PhantomData<TY>,
     _phantom_y: PhantomData<Y>,
 }
@@ -209,6 +210,7 @@ impl<
         Self {
             coefficients: Option::None,
             intercept: Option::None,
+            parameters: Option::None,
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         }
@@ -274,6 +276,7 @@ impl<
         Ok(LinearRegression {
             intercept: Some(*w.get((num_attributes, 0))),
             coefficients: Some(weights),
+            parameters: Some(parameters),
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         })
@@ -300,6 +303,15 @@ impl<
     /// Get estimate of intercept
     pub fn intercept(&self) -> &TX {
         self.intercept.as_ref().unwrap()
+    }
+
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &LinearRegressionParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -308,10 +308,9 @@ impl<
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &LinearRegressionParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&LinearRegressionParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -424,4 +423,41 @@ mod tests {
     //     let parameters: LinearRegressionParameters = serde_json::from_str("{}").unwrap();
     //     assert_eq!(parameters.solver, default.solver);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = LinearRegressionParameters::default();
+        let expected_parameters = parameters.clone();
+        let regression = LinearRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regression
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.solver, expected_parameters.solver);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = LinearRegressionParameters::default();
+        let mut regression = LinearRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regression.parameters = None;
+
+        assert!(regression.parameters().is_none());
+    }
 }

--- a/src/linear/linear_regression.rs
+++ b/src/linear/linear_regression.rs
@@ -423,7 +423,7 @@ mod tests {
     //     let parameters: LinearRegressionParameters = serde_json::from_str("{}").unwrap();
     //     assert_eq!(parameters.solver, default.solver);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -432,9 +432,7 @@ mod tests {
         let parameters = LinearRegressionParameters::default();
         let expected_parameters = parameters.clone();
         let regression = LinearRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
 
@@ -451,9 +449,7 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = LinearRegressionParameters::default();
         let mut regression = LinearRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
         regression.parameters = None;

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -591,7 +591,7 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
 
         optimizer.optimize(&f, &df, &x0, &ls)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -996,19 +996,16 @@ mod tests {
 
         assert_eq!(y_hat.shape(), 52181);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0, 0, 1, 1];
-        let parameters: LogisticRegressionParameters<f64> =
-            LogisticRegressionParameters::default();
+        let parameters: LogisticRegressionParameters<f64> = LogisticRegressionParameters::default();
         let expected_parameters = parameters.clone();
         let regression = LogisticRegression::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
 
@@ -1024,12 +1021,9 @@ mod tests {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0, 0, 1, 1];
-        let parameters: LogisticRegressionParameters<f64> =
-            LogisticRegressionParameters::default();
+        let parameters: LogisticRegressionParameters<f64> = LogisticRegressionParameters::default();
         let mut regression = LogisticRegression::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
         regression.parameters = None;

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -178,6 +178,7 @@ pub struct LogisticRegression<
     classes: Option<Vec<TY>>,
     num_attributes: usize,
     num_classes: usize,
+    parameters: Option<LogisticRegressionParameters<TX>>,
     _phantom_tx: PhantomData<TX>,
     _phantom_y: PhantomData<Y>,
 }
@@ -389,6 +390,7 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
             classes: Option::None,
             num_attributes: 0,
             num_classes: 0,
+            parameters: Option::None,
             _phantom_tx: PhantomData,
             _phantom_y: PhantomData,
         }
@@ -465,6 +467,7 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
                     classes: Some(classes),
                     num_attributes,
                     num_classes: k,
+                    parameters: Some(parameters),
                     _phantom_tx: PhantomData,
                     _phantom_y: PhantomData,
                 })
@@ -491,6 +494,7 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
                     classes: Some(classes),
                     num_attributes,
                     num_classes: k,
+                    parameters: Some(parameters),
                     _phantom_tx: PhantomData,
                     _phantom_y: PhantomData,
                 })
@@ -559,6 +563,15 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
         let optimizer: LBFGS = Default::default();
 
         optimizer.optimize(&f, &df, &x0, &ls)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &LogisticRegressionParameters<TX> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -568,10 +568,9 @@ impl<TX: Number + FloatNumber + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: 
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &LogisticRegressionParameters<TX> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&LogisticRegressionParameters<TX>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -958,5 +957,45 @@ mod tests {
         println!("y_hat shape: {:?}", y_hat.shape());
 
         assert_eq!(y_hat.shape(), 52181);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters: LogisticRegressionParameters<f64> =
+            LogisticRegressionParameters::default();
+        let expected_parameters = parameters.clone();
+        let regression = LogisticRegression::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regression
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.solver, expected_parameters.solver);
+        assert_eq!(actual_parameters.alpha, expected_parameters.alpha);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters: LogisticRegressionParameters<f64> =
+            LogisticRegressionParameters::default();
+        let mut regression = LogisticRegression::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regression.parameters = None;
+
+        assert!(regression.parameters().is_none());
     }
 }

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -91,8 +91,8 @@ pub struct LogisticRegressionParameters<T: Number + FloatNumber> {
     pub alpha: T,
 }
 
-// A manual implementation avoids adding an unnecessary `Default` bound to
-// generic parameter types while preserving their serialized representation.
+// SERDE: a manual implementation avoids the implicit `Default` bounds that
+// `#[derive(Deserialize)]` would add to generic parameter types.
 #[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for LogisticRegressionParameters<T>
 where

--- a/src/linear/logistic_regression.rs
+++ b/src/linear/logistic_regression.rs
@@ -80,7 +80,7 @@ pub enum LogisticRegressionSolverName {
 }
 
 /// Logistic Regression parameters
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone)]
 pub struct LogisticRegressionParameters<T: Number + FloatNumber> {
     #[cfg_attr(feature = "serde", serde(default))]
@@ -89,6 +89,33 @@ pub struct LogisticRegressionParameters<T: Number + FloatNumber> {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Regularization parameter.
     pub alpha: T,
+}
+
+// A manual implementation avoids adding an unnecessary `Default` bound to
+// generic parameter types while preserving their serialized representation.
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for LogisticRegressionParameters<T>
+where
+    T: Number + FloatNumber + Deserialize<'de>,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct LogisticRegressionParametersData<T> {
+            #[serde(default)]
+            solver: LogisticRegressionSolverName,
+            alpha: T,
+        }
+
+        let data = LogisticRegressionParametersData::deserialize(deserializer)?;
+
+        Ok(Self {
+            solver: data.solver,
+            alpha: data.alpha,
+        })
+    }
 }
 
 /// Logistic Regression grid search parameters
@@ -858,12 +885,23 @@ mod tests {
         .unwrap();
         let y: Vec<i32> = vec![0, 0, 1, 1, 2, 1, 1, 0, 0, 2, 1, 1, 0, 0, 1];
 
-        let lr = LogisticRegression::fit(&x, &y, Default::default()).unwrap();
+        let parameters = LogisticRegressionParameters::default().with_alpha(10.0);
+        let expected_parameters = parameters.clone();
+        let lr = LogisticRegression::fit(&x, &y, parameters).unwrap();
 
         let deserialized_lr: LogisticRegression<f64, i32, DenseMatrix<f64>, Vec<i32>> =
             serde_json::from_str(&serde_json::to_string(&lr).unwrap()).unwrap();
 
         assert_eq!(lr, deserialized_lr);
+
+        let actual_parameters = deserialized_lr
+            .parameters()
+            .expect("parameters should survive serialization");
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.solver),
+            std::mem::discriminant(&expected_parameters.solver)
+        );
+        assert_eq!(actual_parameters.alpha, expected_parameters.alpha);
     }
 
     #[cfg_attr(

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -416,10 +416,9 @@ impl<
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &RidgeRegressionParameters<TX> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&RidgeRegressionParameters<TX>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -540,4 +539,43 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: RidgeRegressionParameters<f64> = RidgeRegressionParameters::default();
+        let expected_parameters = parameters.clone();
+        let regression = RidgeRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regression
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.solver, expected_parameters.solver);
+        assert_eq!(actual_parameters.alpha, expected_parameters.alpha);
+        assert_eq!(actual_parameters.normalize, expected_parameters.normalize);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: RidgeRegressionParameters<f64> = RidgeRegressionParameters::default();
+        let mut regression = RidgeRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regression.parameters = None;
+
+        assert!(regression.parameters().is_none());
+    }
 }

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -412,7 +412,7 @@ impl<
     pub fn intercept(&self) -> &TX {
         self.intercept.as_ref().unwrap()
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -539,7 +539,7 @@ mod tests {
 
     //     assert_eq!(lr, deserialized_lr);
     // }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -548,9 +548,7 @@ mod tests {
         let parameters: RidgeRegressionParameters<f64> = RidgeRegressionParameters::default();
         let expected_parameters = parameters.clone();
         let regression = RidgeRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
 
@@ -569,9 +567,7 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters: RidgeRegressionParameters<f64> = RidgeRegressionParameters::default();
         let mut regression = RidgeRegression::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
         regression.parameters = None;

--- a/src/linear/ridge_regression.rs
+++ b/src/linear/ridge_regression.rs
@@ -192,6 +192,7 @@ pub struct RidgeRegression<
 > {
     coefficients: Option<X>,
     intercept: Option<TX>,
+    parameters: Option<RidgeRegressionParameters<TX>>,
     _phantom_ty: PhantomData<TY>,
     _phantom_y: PhantomData<Y>,
 }
@@ -253,6 +254,7 @@ impl<
         Self {
             coefficients: Option::None,
             intercept: Option::None,
+            parameters: Option::None,
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         }
@@ -360,6 +362,7 @@ impl<
         Ok(RidgeRegression {
             intercept: Some(b),
             coefficients: Some(w),
+            parameters: Some(parameters),
             _phantom_ty: PhantomData,
             _phantom_y: PhantomData,
         })
@@ -408,6 +411,15 @@ impl<
     /// Get estimate of intercept
     pub fn intercept(&self) -> &TX {
         self.intercept.as_ref().unwrap()
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &RidgeRegressionParameters<TX> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -386,7 +386,7 @@ pub struct BernoulliNB<
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, BernoulliNBDistribution<TY>>>,
     binarize: Option<TX>,
-    parameters: Option<BernoulliNBParameters<TX>>
+    parameters: Option<BernoulliNBParameters<TX>>,
 }
 
 impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>>
@@ -410,7 +410,7 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
         Self {
             inner: Option::None,
             binarize: Option::None,
-            parameters: Option::None
+            parameters: Option::None,
         }
     }
 
@@ -452,7 +452,7 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
         Ok(Self {
             inner: Some(inner),
             binarize: parameters.binarize,
-            parameters: Some(parameters)
+            parameters: Some(parameters),
         })
     }
 
@@ -706,7 +706,7 @@ mod tests {
             &expected_parameters
         );
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0, 0, 0, 1, 1, 0, 1, 1];
@@ -714,12 +714,9 @@ mod tests {
         let target = vec![0_u32, 0, 1, 1];
         let parameters: BernoulliNBParameters<i32> = BernoulliNBParameters::default();
         let expected_parameters = parameters.clone();
-        let classifier = BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let classifier =
+            BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = classifier
             .parameters()
@@ -733,12 +730,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0_u32, 0, 1, 1];
         let parameters: BernoulliNBParameters<i32> = BernoulliNBParameters::default();
-        let mut classifier = BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut classifier =
+            BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
         classifier.parameters = None;
 
         assert!(classifier.parameters().is_none());

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -441,11 +441,11 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
             BernoulliNBDistribution::fit(
                 &Self::binarize(x, threshold),
                 y,
-                parameters.alpha.clone(),
+                parameters.alpha,
                 parameters.priors.clone(),
             )?
         } else {
-            BernoulliNBDistribution::fit(x, y, parameters.alpha.clone(), parameters.priors.clone())?
+            BernoulliNBDistribution::fit(x, y, parameters.alpha, parameters.priors.clone())?
         };
 
         let inner = BaseNaiveBayes::fit(distribution)?;

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -127,7 +127,7 @@ impl<X: Number + PartialOrd, Y: Number + Ord + Unsigned> NBDistribution<X, Y>
 
 /// `BernoulliNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BernoulliNBParameters<T: Number> {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
@@ -357,6 +357,7 @@ pub struct BernoulliNB<
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, BernoulliNBDistribution<TY>>>,
     binarize: Option<TX>,
+    parameters: Option<BernoulliNBParameters<TX>>
 }
 
 impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>>
@@ -380,6 +381,7 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
         Self {
             inner: Option::None,
             binarize: Option::None,
+            parameters: Option::None
         }
     }
 
@@ -410,17 +412,18 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
             BernoulliNBDistribution::fit(
                 &Self::binarize(x, threshold),
                 y,
-                parameters.alpha,
-                parameters.priors,
+                parameters.alpha.clone(),
+                parameters.priors.clone(),
             )?
         } else {
-            BernoulliNBDistribution::fit(x, y, parameters.alpha, parameters.priors)?
+            BernoulliNBDistribution::fit(x, y, parameters.alpha.clone(), parameters.priors.clone())?
         };
 
         let inner = BaseNaiveBayes::fit(distribution)?;
         Ok(Self {
             inner: Some(inner),
             binarize: parameters.binarize,
+            parameters: Some(parameters)
         })
     }
 
@@ -484,6 +487,15 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
         let mut new_x = x.clone();
         Self::binarize_mut(&mut new_x, threshold);
         new_x
+    }
+
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &BernoulliNBParameters<TX> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -140,8 +140,8 @@ pub struct BernoulliNBParameters<T: Number> {
     pub binarize: Option<T>,
 }
 
-// A manual implementation avoids adding an unnecessary `Default` bound to
-// generic parameter types while preserving their serialized representation.
+// SERDE: a manual implementation avoids the implicit `Default` bounds that
+// `#[derive(Deserialize)]` would add to generic parameter types.
 #[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for BernoulliNBParameters<T>
 where

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -126,7 +126,7 @@ impl<X: Number + PartialOrd, Y: Number + Ord + Unsigned> NBDistribution<X, Y>
 }
 
 /// `BernoulliNB` parameters. Use `Default::default()` for default values.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct BernoulliNBParameters<T: Number> {
     #[cfg_attr(feature = "serde", serde(default))]
@@ -138,6 +138,35 @@ pub struct BernoulliNBParameters<T: Number> {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Threshold for binarizing (mapping to booleans) of sample features. If None, input is presumed to already consist of binary vectors.
     pub binarize: Option<T>,
+}
+
+// A manual implementation avoids adding an unnecessary `Default` bound to
+// generic parameter types while preserving their serialized representation.
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for BernoulliNBParameters<T>
+where
+    T: Number + Deserialize<'de>,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct BernoulliNBParametersData<T> {
+            #[serde(default)]
+            alpha: f64,
+            priors: Option<Vec<f64>>,
+            binarize: Option<T>,
+        }
+
+        let data = BernoulliNBParametersData::deserialize(deserializer)?;
+
+        Ok(Self {
+            alpha: data.alpha,
+            priors: data.priors,
+            binarize: data.binarize,
+        })
+    }
 }
 
 impl<T: Number + PartialOrd> BernoulliNBParameters<T> {
@@ -660,11 +689,22 @@ mod tests {
         .unwrap();
         let y: Vec<u32> = vec![0, 0, 0, 1];
 
-        let bnb = BernoulliNB::fit(&x, &y, Default::default()).unwrap();
+        let parameters = BernoulliNBParameters::default()
+            .with_alpha(0.5)
+            .with_priors(vec![0.75, 0.25])
+            .with_binarize(0);
+        let expected_parameters = parameters.clone();
+        let bnb = BernoulliNB::fit(&x, &y, parameters).unwrap();
         let deserialized_bnb: BernoulliNB<i32, u32, DenseMatrix<i32>, Vec<u32>> =
             serde_json::from_str(&serde_json::to_string(&bnb).unwrap()).unwrap();
 
         assert_eq!(bnb, deserialized_bnb);
+        assert_eq!(
+            deserialized_bnb
+                .parameters()
+                .expect("parameters should survive serialization"),
+            &expected_parameters
+        );
     }
     
     #[test]

--- a/src/naive_bayes/bernoulli.rs
+++ b/src/naive_bayes/bernoulli.rs
@@ -492,10 +492,9 @@ impl<TX: Number + PartialOrd, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &BernoulliNBParameters<TX> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&BernoulliNBParameters<TX>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -666,5 +665,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&bnb).unwrap()).unwrap();
 
         assert_eq!(bnb, deserialized_bnb);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0, 0, 0, 1, 1, 0, 1, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters: BernoulliNBParameters<i32> = BernoulliNBParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier = BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters, &expected_parameters);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0, 0, 0, 1, 1, 0, 1, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters: BernoulliNBParameters<i32> = BernoulliNBParameters::default();
+        let mut classifier = BernoulliNB::<i32, u32, DenseMatrix<i32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -421,10 +421,9 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &CategoricalNBParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&CategoricalNBParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -595,5 +594,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&cnb).unwrap()).unwrap();
 
         assert_eq!(cnb, deserialized_cnb);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0_u32, 0, 0, 1, 1, 0, 1, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = CategoricalNBParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier = CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters, &expected_parameters);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0_u32, 0, 0, 1, 1, 0, 1, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = CategoricalNBParameters::default();
+        let mut classifier = CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -257,7 +257,7 @@ impl<T: Number + Unsigned> CategoricalNBDistribution<T> {
 
 /// `CategoricalNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CategoricalNBParameters {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
@@ -338,6 +338,7 @@ impl Default for CategoricalNBSearchParameters {
 #[derive(Debug, PartialEq)]
 pub struct CategoricalNB<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> {
     inner: Option<BaseNaiveBayes<T, T, X, Y, CategoricalNBDistribution<T>>>,
+    parameters: Option<CategoricalNBParameters>
 }
 
 impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>>
@@ -346,6 +347,7 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>>
     fn new() -> Self {
         Self {
             inner: Option::None,
+            parameters: Option::None
         }
     }
 
@@ -370,7 +372,7 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
         let alpha = parameters.alpha;
         let distribution = CategoricalNBDistribution::fit(x, y, alpha)?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner) })
+        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
     }
 
     /// Estimates the class labels for the provided data.
@@ -414,6 +416,15 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
     /// of categories given the respective feature and class, ``P(x_i|y)``.
     pub fn feature_log_prob(&self) -> &Vec<Vec<Vec<f64>>> {
         &self.inner.as_ref().unwrap().distribution.coefficients
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &CategoricalNBParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/naive_bayes/categorical.rs
+++ b/src/naive_bayes/categorical.rs
@@ -338,7 +338,7 @@ impl Default for CategoricalNBSearchParameters {
 #[derive(Debug, PartialEq)]
 pub struct CategoricalNB<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> {
     inner: Option<BaseNaiveBayes<T, T, X, Y, CategoricalNBDistribution<T>>>,
-    parameters: Option<CategoricalNBParameters>
+    parameters: Option<CategoricalNBParameters>,
 }
 
 impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>>
@@ -347,7 +347,7 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>>
     fn new() -> Self {
         Self {
             inner: Option::None,
-            parameters: Option::None
+            parameters: Option::None,
         }
     }
 
@@ -372,7 +372,10 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
         let alpha = parameters.alpha;
         let distribution = CategoricalNBDistribution::fit(x, y, alpha)?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
+        Ok(Self {
+            inner: Some(inner),
+            parameters: Some(parameters),
+        })
     }
 
     /// Estimates the class labels for the provided data.
@@ -417,7 +420,7 @@ impl<T: Number + Unsigned, X: Array2<T>, Y: Array1<T>> CategoricalNB<T, X, Y> {
     pub fn feature_log_prob(&self) -> &Vec<Vec<Vec<f64>>> {
         &self.inner.as_ref().unwrap().distribution.coefficients
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -595,7 +598,7 @@ mod tests {
 
         assert_eq!(cnb, deserialized_cnb);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0_u32, 0, 0, 1, 1, 0, 1, 1];
@@ -603,12 +606,9 @@ mod tests {
         let target = vec![0_u32, 0, 1, 1];
         let parameters = CategoricalNBParameters::default();
         let expected_parameters = parameters.clone();
-        let classifier = CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let classifier =
+            CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = classifier
             .parameters()
@@ -622,12 +622,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0_u32, 0, 1, 1];
         let parameters = CategoricalNBParameters::default();
-        let mut classifier = CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut classifier =
+            CategoricalNB::<u32, DenseMatrix<u32>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
         classifier.parameters = None;
 
         assert!(classifier.parameters().is_none());

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -92,7 +92,7 @@ impl<X: Number + RealNumber, Y: Number + Ord + Unsigned> NBDistribution<X, Y>
 
 /// `GaussianNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct GaussianNBParameters {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Prior probabilities of the classes. If specified the priors are not adjusted according to the data
@@ -266,6 +266,7 @@ pub struct GaussianNB<
     Y: Array1<TY>,
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, GaussianNBDistribution<TY>>>,
+    parameters: Option<GaussianNBParameters>
 }
 
 impl<
@@ -291,6 +292,7 @@ impl<
     fn new() -> Self {
         Self {
             inner: Option::None,
+            parameters: Option::None,
         }
     }
 
@@ -320,9 +322,9 @@ impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     /// * `y` - vector with target values (classes) of length N.
     /// * `parameters` - additional parameters like class priors.
     pub fn fit(x: &X, y: &Y, parameters: GaussianNBParameters) -> Result<Self, Failed> {
-        let distribution = GaussianNBDistribution::fit(x, y, parameters.priors)?;
+        let distribution = GaussianNBDistribution::fit(x, y, parameters.priors.clone())?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner) })
+        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
     }
 
     /// Estimates the class labels for the provided data.
@@ -361,6 +363,15 @@ impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     /// Returns a 2d vector of shape (n_classes, n_features).
     pub fn var(&self) -> &Vec<Vec<f64>> {
         &self.inner.as_ref().unwrap().distribution.var
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &GaussianNBParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -266,7 +266,7 @@ pub struct GaussianNB<
     Y: Array1<TY>,
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, GaussianNBDistribution<TY>>>,
-    parameters: Option<GaussianNBParameters>
+    parameters: Option<GaussianNBParameters>,
 }
 
 impl<
@@ -324,7 +324,10 @@ impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     pub fn fit(x: &X, y: &Y, parameters: GaussianNBParameters) -> Result<Self, Failed> {
         let distribution = GaussianNBDistribution::fit(x, y, parameters.priors.clone())?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
+        Ok(Self {
+            inner: Some(inner),
+            parameters: Some(parameters),
+        })
     }
 
     /// Estimates the class labels for the provided data.
@@ -364,7 +367,7 @@ impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     pub fn var(&self) -> &Vec<Vec<f64>> {
         &self.inner.as_ref().unwrap().distribution.var
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -484,7 +487,7 @@ mod tests {
 
         assert_eq!(gnb, deserialized_gnb);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -492,12 +495,9 @@ mod tests {
         let target = vec![0_u32, 0, 1, 1];
         let parameters = GaussianNBParameters::default();
         let expected_parameters = parameters.clone();
-        let classifier = GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let classifier =
+            GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = classifier
             .parameters()
@@ -511,12 +511,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0_u32, 0, 1, 1];
         let parameters = GaussianNBParameters::default();
-        let mut classifier = GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut classifier =
+            GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(&matrix, &target, parameters)
+                .unwrap();
         classifier.parameters = None;
 
         assert!(classifier.parameters().is_none());

--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -368,10 +368,9 @@ impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Arr
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &GaussianNBParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&GaussianNBParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -484,5 +483,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&gnb).unwrap()).unwrap();
 
         assert_eq!(gnb, deserialized_gnb);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = GaussianNBParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier = GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters, &expected_parameters);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = GaussianNBParameters::default();
+        let mut classifier = GaussianNB::<f64, u32, DenseMatrix<f64>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -397,10 +397,9 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &MultinomialNBParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&MultinomialNBParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -576,5 +575,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&mnb).unwrap()).unwrap();
 
         assert_eq!(mnb, deserialized_mnb);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0_u32, 1, 1, 0, 1, 2, 2, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = MultinomialNBParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier = MultinomialNB::<u32, u32, DenseMatrix<u32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters, &expected_parameters);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0_u32, 1, 1, 0, 1, 2, 2, 1];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0_u32, 0, 1, 1];
+        let parameters = MultinomialNBParameters::default();
+        let mut classifier = MultinomialNB::<u32, u32, DenseMatrix<u32>, Vec<u32>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -99,7 +99,7 @@ impl<X: Number + Unsigned, Y: Number + Ord + Unsigned> NBDistribution<X, Y>
 
 /// `MultinomialNB` parameters. Use `Default::default()` for default values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MultinomialNBParameters {
     #[cfg_attr(feature = "serde", serde(default))]
     /// Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
@@ -302,6 +302,7 @@ pub struct MultinomialNB<
     Y: Array1<TY>,
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, MultinomialNBDistribution<TY>>>,
+    parameters: Option<MultinomialNBParameters>
 }
 
 impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>> fmt::Display
@@ -323,6 +324,7 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     fn new() -> Self {
         Self {
             inner: Option::None,
+            parameters: Option::None
         }
     }
 
@@ -350,9 +352,9 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     ///   binarizing threshold.
     pub fn fit(x: &X, y: &Y, parameters: MultinomialNBParameters) -> Result<Self, Failed> {
         let distribution =
-            MultinomialNBDistribution::fit(x, y, parameters.alpha, parameters.priors)?;
+            MultinomialNBDistribution::fit(x, y, parameters.alpha.clone(), parameters.priors.clone())?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner) })
+        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
     }
 
     /// Estimates the class labels for the provided data.
@@ -390,6 +392,15 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     /// Returns a 2d vector of shape (n_classes, n_features)
     pub fn feature_count(&self) -> &Vec<Vec<usize>> {
         &self.inner.as_ref().unwrap().distribution.feature_count
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &MultinomialNBParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -354,7 +354,7 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
         let distribution = MultinomialNBDistribution::fit(
             x,
             y,
-            parameters.alpha.clone(),
+            parameters.alpha,
             parameters.priors.clone(),
         )?;
         let inner = BaseNaiveBayes::fit(distribution)?;

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -351,12 +351,8 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     /// * `parameters` - additional parameters like class priors, alpha for smoothing and
     ///   binarizing threshold.
     pub fn fit(x: &X, y: &Y, parameters: MultinomialNBParameters) -> Result<Self, Failed> {
-        let distribution = MultinomialNBDistribution::fit(
-            x,
-            y,
-            parameters.alpha,
-            parameters.priors.clone(),
-        )?;
+        let distribution =
+            MultinomialNBDistribution::fit(x, y, parameters.alpha, parameters.priors.clone())?;
         let inner = BaseNaiveBayes::fit(distribution)?;
         Ok(Self {
             inner: Some(inner),

--- a/src/naive_bayes/multinomial.rs
+++ b/src/naive_bayes/multinomial.rs
@@ -302,7 +302,7 @@ pub struct MultinomialNB<
     Y: Array1<TY>,
 > {
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, MultinomialNBDistribution<TY>>>,
-    parameters: Option<MultinomialNBParameters>
+    parameters: Option<MultinomialNBParameters>,
 }
 
 impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>> fmt::Display
@@ -324,7 +324,7 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     fn new() -> Self {
         Self {
             inner: Option::None,
-            parameters: Option::None
+            parameters: Option::None,
         }
     }
 
@@ -351,10 +351,17 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     /// * `parameters` - additional parameters like class priors, alpha for smoothing and
     ///   binarizing threshold.
     pub fn fit(x: &X, y: &Y, parameters: MultinomialNBParameters) -> Result<Self, Failed> {
-        let distribution =
-            MultinomialNBDistribution::fit(x, y, parameters.alpha.clone(), parameters.priors.clone())?;
+        let distribution = MultinomialNBDistribution::fit(
+            x,
+            y,
+            parameters.alpha.clone(),
+            parameters.priors.clone(),
+        )?;
         let inner = BaseNaiveBayes::fit(distribution)?;
-        Ok(Self { inner: Some(inner), parameters: Some(parameters) })
+        Ok(Self {
+            inner: Some(inner),
+            parameters: Some(parameters),
+        })
     }
 
     /// Estimates the class labels for the provided data.
@@ -393,7 +400,7 @@ impl<TX: Number + Unsigned, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array
     pub fn feature_count(&self) -> &Vec<Vec<usize>> {
         &self.inner.as_ref().unwrap().distribution.feature_count
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -576,7 +583,7 @@ mod tests {
 
         assert_eq!(mnb, deserialized_mnb);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0_u32, 1, 1, 0, 1, 2, 2, 1];
@@ -585,9 +592,7 @@ mod tests {
         let parameters = MultinomialNBParameters::default();
         let expected_parameters = parameters.clone();
         let classifier = MultinomialNB::<u32, u32, DenseMatrix<u32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
 
@@ -604,9 +609,7 @@ mod tests {
         let target = vec![0_u32, 0, 1, 1];
         let parameters = MultinomialNBParameters::default();
         let mut classifier = MultinomialNB::<u32, u32, DenseMatrix<u32>, Vec<u32>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
         classifier.parameters = None;

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -83,6 +83,7 @@ pub struct KNNClassifier<
     knn_algorithm: Option<KNNAlgorithm<TX, D>>,
     weight: Option<KNNWeightFunction>,
     k: Option<usize>,
+    parameters: Option<KNNClassifierParameters<TX, D>>,
     _phantom_tx: PhantomData<TX>,
     _phantom_x: PhantomData<X>,
     _phantom_y: PhantomData<Y>,
@@ -188,6 +189,7 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
             knn_algorithm: Option::None,
             weight: Option::None,
             k: Option::None,
+            parameters: Option::None,
             _phantom_tx: PhantomData,
             _phantom_x: PhantomData,
             _phantom_y: PhantomData,
@@ -250,9 +252,10 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
         Ok(KNNClassifier {
             classes: Some(classes),
             y: Some(yi),
-            k: Some(parameters.k),
-            knn_algorithm: Some(parameters.algorithm.fit(data, parameters.distance)?),
-            weight: Some(parameters.weight),
+            k: Some(parameters.k.clone()),
+            knn_algorithm: Some(parameters.algorithm.fit(data, parameters.distance.clone())?),
+            weight: Some(parameters.weight.clone()),
+            parameters: Some(parameters),
             _phantom_tx: PhantomData,
             _phantom_x: PhantomData,
             _phantom_y: PhantomData,
@@ -343,6 +346,15 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
         }
 
         Ok(result)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &KNNClassifierParameters<TX, D> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -68,8 +68,8 @@ pub struct KNNClassifierParameters<T: Number, D: Distance<Vec<T>>> {
     t: PhantomData<T>,
 }
 
-// A manual implementation avoids adding an unnecessary `Default` bound to
-// generic parameter types while preserving their serialized representation.
+// SERDE: a manual implementation avoids the implicit `Default` bounds that
+// `#[derive(Deserialize)]` would add to generic parameter types.
 #[cfg(feature = "serde")]
 impl<'de, T, D> Deserialize<'de> for KNNClassifierParameters<T, D>
 where

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -289,7 +289,7 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
         Ok(KNNClassifier {
             classes: Some(classes),
             y: Some(yi),
-            k: Some(parameters.k.clone()),
+            k: Some(parameters.k),
             knn_algorithm: Some(
                 parameters
                     .algorithm

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -46,7 +46,7 @@ use crate::neighbors::KNNWeightFunction;
 use crate::numbers::basenum::Number;
 
 /// `KNNClassifier` parameters. Use `Default::default()` for default values.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone)]
 pub struct KNNClassifierParameters<T: Number, D: Distance<Vec<T>>> {
     #[cfg_attr(feature = "serde", serde(default))]
@@ -66,6 +66,43 @@ pub struct KNNClassifierParameters<T: Number, D: Distance<Vec<T>>> {
     #[cfg_attr(feature = "serde", serde(default))]
     /// this parameter is not used
     t: PhantomData<T>,
+}
+
+// A manual implementation avoids adding an unnecessary `Default` bound to
+// generic parameter types while preserving their serialized representation.
+#[cfg(feature = "serde")]
+impl<'de, T, D> Deserialize<'de> for KNNClassifierParameters<T, D>
+where
+    T: Number,
+    D: Distance<Vec<T>> + Deserialize<'de>,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct KNNClassifierParametersData<D> {
+            distance: D,
+            #[serde(default)]
+            algorithm: KNNAlgorithmName,
+            #[serde(default)]
+            weight: KNNWeightFunction,
+            #[serde(default)]
+            k: usize,
+            #[serde(default, rename = "t")]
+            _t: PhantomData<()>,
+        }
+
+        let data = KNNClassifierParametersData::deserialize(deserializer)?;
+
+        Ok(Self {
+            distance: data.distance,
+            algorithm: data.algorithm,
+            weight: data.weight,
+            k: data.k,
+            t: PhantomData,
+        })
+    }
 }
 
 /// K Nearest Neighbors Classifier
@@ -731,10 +768,32 @@ mod tests {
                 .unwrap();
         let y = vec![2, 2, 2, 3, 3];
 
-        let knn = KNNClassifier::fit(&x, &y, Default::default()).unwrap();
+        let parameters = KNNClassifierParameters::default()
+            .with_k(2)
+            .with_algorithm(KNNAlgorithmName::LinearSearch)
+            .with_weight(KNNWeightFunction::Distance);
+        let expected_parameters = parameters.clone();
+        let knn = KNNClassifier::fit(&x, &y, parameters).unwrap();
         let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
+
+        let actual_parameters = deserialized_knn
+            .parameters()
+            .expect("parameters should survive serialization");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.weight),
+            std::mem::discriminant(&expected_parameters.weight)
+        );
+        assert_eq!(actual_parameters.k, expected_parameters.k);
     }
     
     #[test]

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -351,10 +351,9 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &KNNClassifierParameters<TX, D> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&KNNClassifierParameters<TX, D>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -736,5 +735,58 @@ mod tests {
         let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters: KNNClassifierParameters<f64, Euclidian<f64>> =
+            KNNClassifierParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier =
+            KNNClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>, Euclidian<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.weight),
+            std::mem::discriminant(&expected_parameters.weight)
+        );
+        assert_eq!(actual_parameters.k, expected_parameters.k);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters: KNNClassifierParameters<f64, Euclidian<f64>> =
+            KNNClassifierParameters::default();
+        let mut classifier =
+            KNNClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>, Euclidian<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -290,7 +290,11 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
             classes: Some(classes),
             y: Some(yi),
             k: Some(parameters.k.clone()),
-            knn_algorithm: Some(parameters.algorithm.fit(data, parameters.distance.clone())?),
+            knn_algorithm: Some(
+                parameters
+                    .algorithm
+                    .fit(data, parameters.distance.clone())?,
+            ),
             weight: Some(parameters.weight.clone()),
             parameters: Some(parameters),
             _phantom_tx: PhantomData,
@@ -384,7 +388,7 @@ impl<TX: Number, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec
 
         Ok(result)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -795,7 +799,7 @@ mod tests {
         );
         assert_eq!(actual_parameters.k, expected_parameters.k);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -806,9 +810,7 @@ mod tests {
         let expected_parameters = parameters.clone();
         let classifier =
             KNNClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>, Euclidian<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
+                &matrix, &target, parameters,
             )
             .unwrap();
 
@@ -839,9 +841,7 @@ mod tests {
             KNNClassifierParameters::default();
         let mut classifier =
             KNNClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>, Euclidian<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
+                &matrix, &target, parameters,
             )
             .unwrap();
         classifier.parameters = None;

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -49,7 +49,7 @@ use crate::neighbors::KNNWeightFunction;
 use crate::numbers::basenum::Number;
 
 /// `KNNRegressor` parameters. Use `Default::default()` for default values.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone)]
 pub struct KNNRegressorParameters<T: Number, D: Distance<Vec<T>>> {
     #[cfg_attr(feature = "serde", serde(default))]
@@ -69,6 +69,43 @@ pub struct KNNRegressorParameters<T: Number, D: Distance<Vec<T>>> {
     #[cfg_attr(feature = "serde", serde(default))]
     /// this parameter is not used
     t: PhantomData<T>,
+}
+
+// A manual implementation avoids adding an unnecessary `Default` bound to
+// generic parameter types while preserving their serialized representation.
+#[cfg(feature = "serde")]
+impl<'de, T, D> Deserialize<'de> for KNNRegressorParameters<T, D>
+where
+    T: Number,
+    D: Distance<Vec<T>> + Deserialize<'de>,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct KNNRegressorParameters<D> {
+            distance: D,
+            #[serde(default)]
+            algorithm: KNNAlgorithmName,
+            #[serde(default)]
+            weight: KNNWeightFunction,
+            #[serde(default)]
+            k: usize,
+            #[serde(default, rename = "t")]
+            _t: PhantomData<()>,
+        }
+
+        let data = KNNRegressorParameters::deserialize(deserializer)?;
+
+        Ok(Self {
+            distance: data.distance,
+            algorithm: data.algorithm,
+            weight: data.weight,
+            k: data.k,
+            t: PhantomData,
+        })
+    }
 }
 
 /// K Nearest Neighbors Regressor
@@ -355,13 +392,34 @@ mod tests {
                 .unwrap();
         let y = vec![1., 2., 3., 4., 5.];
 
-        let knn = KNNRegressor::fit(&x, &y, Default::default()).unwrap();
-
+        let parameters = KNNRegressorParameters::default()
+            .with_k(2)
+            .with_algorithm(KNNAlgorithmName::LinearSearch)
+            .with_weight(KNNWeightFunction::Distance);
+        let expected_parameters = parameters.clone();
+        let knn = KNNRegressor::fit(&x, &y, parameters).unwrap();
         let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
+
+        let actual_parameters = deserialized_knn
+            .parameters()
+            .expect("parameters should survive serialization");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.weight),
+            std::mem::discriminant(&expected_parameters.weight)
+        );
+        assert_eq!(actual_parameters.k, expected_parameters.k);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -80,6 +80,7 @@ pub struct KNNRegressor<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D:
     knn_algorithm: Option<KNNAlgorithm<TX, D>>,
     weight: Option<KNNWeightFunction>,
     k: Option<usize>,
+    parameters: Option<KNNRegressorParameters<TX, D>>,
     _phantom_tx: PhantomData<TX>,
     _phantom_ty: PhantomData<TY>,
     _phantom_x: PhantomData<X>,
@@ -179,6 +180,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
             knn_algorithm: Option::None,
             weight: Option::None,
             k: Option::None,
+            parameters: Option::None,
             _phantom_tx: PhantomData,
             _phantom_ty: PhantomData,
             _phantom_x: PhantomData,
@@ -231,13 +233,14 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
             )));
         }
 
-        let knn_algo = parameters.algorithm.fit(data, parameters.distance)?;
+        let knn_algo = parameters.algorithm.fit(data, parameters.distance.clone())?;
 
         Ok(KNNRegressor {
             y: Some(y.clone()),
-            k: Some(parameters.k),
+            k: Some(parameters.k.clone()),
             knn_algorithm: Some(knn_algo),
-            weight: Some(parameters.weight),
+            weight: Some(parameters.weight.clone()),
+            parameters: Some(parameters),
             _phantom_tx: PhantomData,
             _phantom_ty: PhantomData,
             _phantom_x: PhantomData,
@@ -276,6 +279,15 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
         }
 
         Ok(result)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &KNNRegressorParameters<TX, D> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -284,10 +284,9 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &KNNRegressorParameters<TX, D> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&KNNRegressorParameters<TX, D>> {
+        self.parameters.as_ref()
     }
 }
 
@@ -361,5 +360,58 @@ mod tests {
         let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: KNNRegressorParameters<f64, Euclidian<f64>> =
+            KNNRegressorParameters::default();
+        let expected_parameters = parameters.clone();
+        let regressor =
+            KNNRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(
+            format!("{:?}", actual_parameters.distance),
+            format!("{:?}", expected_parameters.distance)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.algorithm),
+            std::mem::discriminant(&expected_parameters.algorithm)
+        );
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.weight),
+            std::mem::discriminant(&expected_parameters.weight)
+        );
+        assert_eq!(actual_parameters.k, expected_parameters.k);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: KNNRegressorParameters<f64, Euclidian<f64>> =
+            KNNRegressorParameters::default();
+        let mut regressor =
+            KNNRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -276,7 +276,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
 
         Ok(KNNRegressor {
             y: Some(y.clone()),
-            k: Some(parameters.k.clone()),
+            k: Some(parameters.k),
             knn_algorithm: Some(knn_algo),
             weight: Some(parameters.weight.clone()),
             parameters: Some(parameters),

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -270,7 +270,9 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
             )));
         }
 
-        let knn_algo = parameters.algorithm.fit(data, parameters.distance.clone())?;
+        let knn_algo = parameters
+            .algorithm
+            .fit(data, parameters.distance.clone())?;
 
         Ok(KNNRegressor {
             y: Some(y.clone()),
@@ -317,7 +319,7 @@ impl<TX: Number, TY: Number, X: Array2<TX>, Y: Array1<TY>, D: Distance<Vec<TX>>>
 
         Ok(result)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -428,13 +430,10 @@ mod tests {
         let parameters: KNNRegressorParameters<f64, Euclidian<f64>> =
             KNNRegressorParameters::default();
         let expected_parameters = parameters.clone();
-        let regressor =
-            KNNRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let regressor = KNNRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = regressor
             .parameters()
@@ -463,9 +462,7 @@ mod tests {
             KNNRegressorParameters::default();
         let mut regressor =
             KNNRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>, Euclidian<f64>>::fit(
-                &matrix,
-                &target,
-                parameters,
+                &matrix, &target, parameters,
             )
             .unwrap();
         regressor.parameters = None;

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -71,8 +71,8 @@ pub struct KNNRegressorParameters<T: Number, D: Distance<Vec<T>>> {
     t: PhantomData<T>,
 }
 
-// A manual implementation avoids adding an unnecessary `Default` bound to
-// generic parameter types while preserving their serialized representation.
+// SERDE: a manual implementation avoids the implicit `Default` bounds that
+// `#[derive(Deserialize)]` would add to generic parameter types.
 #[cfg(feature = "serde")]
 impl<'de, T, D> Deserialize<'de> for KNNRegressorParameters<T, D>
 where

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -292,7 +292,7 @@ pub struct SVCParameters<TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX
     /// Unused parameter.
     m: PhantomData<(X, Y, TY)>,
     /// Controls the pseudo random number generation for shuffling the data for probability estimates
-    seed: Option<u64>,
+    pub seed: Option<u64>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -607,6 +607,15 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX> + 'a, Y: Array
         }
 
         f
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &SVCParameters<TX, TY, X, Y> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -271,6 +271,15 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>
             })
             .collect())
     }
+
+    /// Returns the parameters shared by the binary classifiers.
+    ///
+    /// Every one-vs-one classifier is fitted with the same borrowed parameter
+    /// value. This returns `None` if the model has not been fitted or contains
+    /// no binary classifiers.
+    pub fn parameters(&self) -> Option<&SVCParameters<TX, TY, X, Y>> {
+        self.classifiers.as_ref()?.first()?.parameters
+    }
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -609,10 +618,11 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX> + 'a, Y: Array
         f
     }
 
-    /// Getter for parameters used in the model
+    /// Returns the parameters used to fit this classifier.
     ///
-    /// # Returns
-    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    /// A fitted `SVC` borrows its parameter value. With the `serde` feature,
+    /// that borrow is skipped during serialization, so this method returns
+    /// `None` for a deserialized classifier.
     pub fn parameters(&self) -> Option<&SVCParameters<TX, TY, X, Y>> {
         self.parameters
     }
@@ -1380,10 +1390,20 @@ mod tests {
             .with_kernel(knl)
             .with_seed(Some(100));
 
-        let y_hat = MultiClassSVC::fit(&x, &y, &parameters)
-            .and_then(|lr| lr.predict(&x))
-            .unwrap();
+        let classifier = MultiClassSVC::fit(&x, &y, &parameters).unwrap();
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.epoch, parameters.epoch);
+        assert_eq!(actual_parameters.c, parameters.c);
+        assert_eq!(actual_parameters.tol, parameters.tol);
+        assert_eq!(actual_parameters.seed, parameters.seed);
+        assert_eq!(
+            format!("{:?}", actual_parameters.kernel),
+            format!("{:?}", parameters.kernel)
+        );
 
+        let y_hat = classifier.predict(&x).unwrap();
         let acc = accuracy(&y, &(y_hat.iter().map(|e| e.to_i32().unwrap()).collect()));
 
         assert!(
@@ -1436,6 +1456,10 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&svc).unwrap()).unwrap();
 
         assert_eq!(svc, deserialized_svc);
+        assert!(
+            deserialized_svc.parameters().is_none(),
+            "borrowed SVC parameters are not serialized"
+        );
     }
 
     #[test]

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -608,7 +608,7 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX> + 'a, Y: Array
 
         f
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -1437,7 +1437,7 @@ mod tests {
 
         assert_eq!(svc, deserialized_svc);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];

--- a/src/svm/svc.rs
+++ b/src/svm/svc.rs
@@ -612,10 +612,9 @@ impl<'a, TX: Number + RealNumber, TY: Number + Ord, X: Array2<TX> + 'a, Y: Array
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &SVCParameters<TX, TY, X, Y> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&SVCParameters<TX, TY, X, Y>> {
+        self.parameters
     }
 }
 
@@ -1437,5 +1436,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&svc).unwrap()).unwrap();
 
         assert_eq!(svc, deserialized_svc);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![-1, -1, 1, 1];
+        let parameters: SVCParameters<f64, i32, DenseMatrix<f64>, Vec<i32>> =
+            SVCParameters::default().with_kernel(Kernels::linear());
+        let classifier: SVC<'_, f64, i32, DenseMatrix<f64>, Vec<i32>> =
+            SVC::fit(&matrix, &target, &parameters).unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.epoch, parameters.epoch);
+        assert_eq!(actual_parameters.c, parameters.c);
+        assert_eq!(actual_parameters.tol, parameters.tol);
+        assert_eq!(
+            format!("{:?}", actual_parameters.kernel),
+            format!("{:?}", parameters.kernel)
+        );
+        assert_eq!(actual_parameters.seed, parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![-1, -1, 1, 1];
+        let parameters: SVCParameters<f64, i32, DenseMatrix<f64>, Vec<i32>> =
+            SVCParameters::default().with_kernel(Kernels::linear());
+        let mut classifier: SVC<'_, f64, i32, DenseMatrix<f64>, Vec<i32>> =
+            SVC::fit(&matrix, &target, &parameters).unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -280,6 +280,15 @@ impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> SVR<'
 
         T::from(f).unwrap()
     }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &SVRParameters<T> {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
+    }
 }
 
 impl<T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> PartialEq

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -280,7 +280,7 @@ impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> SVR<'
 
         T::from(f).unwrap()
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -716,7 +716,7 @@ mod tests {
 
         assert_eq!(svr, deserialized_svr);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];

--- a/src/svm/svr.rs
+++ b/src/svm/svr.rs
@@ -284,10 +284,9 @@ impl<'a, T: Number + FloatNumber + PartialOrd, X: Array2<T>, Y: Array1<T>> SVR<'
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &SVRParameters<T> {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&SVRParameters<T>> {
+        self.parameters
     }
 }
 
@@ -716,5 +715,38 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&svr).unwrap()).unwrap();
 
         assert_eq!(svr, deserialized_svr);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: SVRParameters<f64> =
+            SVRParameters::default().with_kernel(Kernels::linear());
+        let regressor: SVR<'_, f64, DenseMatrix<f64>, Vec<f64>> =
+            SVR::fit(&matrix, &target, &parameters).unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.eps, parameters.eps);
+        assert_eq!(actual_parameters.c, parameters.c);
+        assert_eq!(actual_parameters.tol, parameters.tol);
+        assert_eq!(actual_parameters.kernel, parameters.kernel);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters: SVRParameters<f64> =
+            SVRParameters::default().with_kernel(Kernels::linear());
+        let mut regressor: SVR<'_, f64, DenseMatrix<f64>, Vec<f64>> =
+            SVR::fit(&matrix, &target, &parameters).unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }

--- a/src/tree/base_tree_regressor.rs
+++ b/src/tree/base_tree_regressor.rs
@@ -240,7 +240,13 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
             visitor_queue.push_back(visitor);
         }
 
-        while base_tree.depth() < base_tree.parameters().expect("parameters not set — model not fitted").max_depth.unwrap_or(u16::MAX) {
+        while base_tree.depth()
+            < base_tree
+                .parameters()
+                .expect("parameters not set — model not fitted")
+                .max_depth
+                .unwrap_or(u16::MAX)
+        {
             match visitor_queue.pop_front() {
                 Some(node) => base_tree.split(node, mtry, &mut visitor_queue, &mut rng),
                 None => break,
@@ -301,8 +307,10 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
         let n: usize = visitor.samples.iter().sum();
 
-        let parameters = self.parameters().expect("parameters not set — model not fitted");
-        
+        let parameters = self
+            .parameters()
+            .expect("parameters not set — model not fitted");
+
         if n < parameters.min_samples_split {
             return false;
         }
@@ -385,11 +393,11 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
         let false_count = n - true_count;
 
-        let parameters = self.parameters().expect("parameters not set — model not fitted");
+        let parameters = self
+            .parameters()
+            .expect("parameters not set — model not fitted");
 
-        if true_count < parameters.min_samples_leaf
-            || false_count < parameters.min_samples_leaf
-        {
+        if true_count < parameters.min_samples_leaf || false_count < parameters.min_samples_leaf {
             return;
         }
 
@@ -443,7 +451,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
                 let false_count = n - true_count;
 
-                let parameters = self.parameters().expect("parameters not set — model not fitted");
+                let parameters = self
+                    .parameters()
+                    .expect("parameters not set — model not fitted");
 
                 if true_count < parameters.min_samples_leaf
                     || false_count < parameters.min_samples_leaf
@@ -510,7 +520,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
             }
         }
 
-        let parameters = self.parameters().expect("parameters not set — model not fitted");
+        let parameters = self
+            .parameters()
+            .expect("parameters not set — model not fitted");
 
         if tc < parameters.min_samples_leaf || fc < parameters.min_samples_leaf {
             self.nodes[visitor.node].split_feature = 0;

--- a/src/tree/base_tree_regressor.rs
+++ b/src/tree/base_tree_regressor.rs
@@ -66,10 +66,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    fn parameters(&self) -> &BaseTreeRegressorParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    fn parameters(&self) -> Option<&BaseTreeRegressorParameters> {
+        self.parameters.as_ref()
     }
     /// Get estimate of intercept, return value
     fn depth(&self) -> u16 {
@@ -241,7 +240,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
             visitor_queue.push_back(visitor);
         }
 
-        while base_tree.depth() < base_tree.parameters().max_depth.unwrap_or(u16::MAX) {
+        while base_tree.depth() < base_tree.parameters().expect("parameters not set — model not fitted").max_depth.unwrap_or(u16::MAX) {
             match visitor_queue.pop_front() {
                 Some(node) => base_tree.split(node, mtry, &mut visitor_queue, &mut rng),
                 None => break,
@@ -302,7 +301,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
         let n: usize = visitor.samples.iter().sum();
 
-        if n < self.parameters().min_samples_split {
+        let parameters = self.parameters().expect("parameters not set — model not fitted");
+        
+        if n < parameters.min_samples_split {
             return false;
         }
 
@@ -317,7 +318,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         let parent_gain =
             n as f64 * self.nodes()[visitor.node].output * self.nodes()[visitor.node].output;
 
-        let splitter = self.parameters().splitter.clone();
+        let splitter = parameters.splitter.clone();
 
         for variable in variables.iter().take(mtry) {
             match splitter {
@@ -384,8 +385,10 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
         let false_count = n - true_count;
 
-        if true_count < self.parameters().min_samples_leaf
-            || false_count < self.parameters().min_samples_leaf
+        let parameters = self.parameters().expect("parameters not set — model not fitted");
+
+        if true_count < parameters.min_samples_leaf
+            || false_count < parameters.min_samples_leaf
         {
             return;
         }
@@ -440,8 +443,10 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 
                 let false_count = n - true_count;
 
-                if true_count < self.parameters().min_samples_leaf
-                    || false_count < self.parameters().min_samples_leaf
+                let parameters = self.parameters().expect("parameters not set — model not fitted");
+
+                if true_count < parameters.min_samples_leaf
+                    || false_count < parameters.min_samples_leaf
                 {
                     prevx = Some(x_ij);
                     true_count += visitor.samples[*i];
@@ -505,7 +510,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
             }
         }
 
-        if tc < self.parameters().min_samples_leaf || fc < self.parameters().min_samples_leaf {
+        let parameters = self.parameters().expect("parameters not set — model not fitted");
+
+        if tc < parameters.min_samples_leaf || fc < parameters.min_samples_leaf {
             self.nodes[visitor.node].split_feature = 0;
             self.nodes[visitor.node].split_value = Option::None;
             self.nodes[visitor.node].split_score = Option::None;

--- a/src/tree/base_tree_regressor.rs
+++ b/src/tree/base_tree_regressor.rs
@@ -63,9 +63,13 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     fn nodes(&self) -> &Vec<Node> {
         self.nodes.as_ref()
     }
-    /// Get parameters, return a shared reference
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
     fn parameters(&self) -> &BaseTreeRegressorParameters {
-        self.parameters.as_ref().unwrap()
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
     /// Get estimate of intercept, return value
     fn depth(&self) -> u16 {

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -131,9 +131,13 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
     fn nodes(&self) -> &Vec<Node> {
         self.nodes.as_ref()
     }
-    /// Get parameters, return a shared reference
-    fn parameters(&self) -> &DecisionTreeClassifierParameters {
-        self.parameters.as_ref().unwrap()
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &DecisionTreeClassifierParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
     /// get classes vector, return a shared reference
     fn classes(&self) -> &Vec<TY> {

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -134,10 +134,9 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &DecisionTreeClassifierParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&DecisionTreeClassifierParameters> {
+        self.parameters.as_ref()
     }
     /// get classes vector, return a shared reference
     fn classes(&self) -> &Vec<TY> {
@@ -619,7 +618,7 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
             visitor_queue.push_back(visitor);
         }
 
-        while tree.depth() < tree.parameters().max_depth.unwrap_or(u16::MAX) {
+        while tree.depth() < tree.parameters().expect("parameters not set — model not fitted").max_depth.unwrap_or(u16::MAX) {
             match visitor_queue.pop_front() {
                 Some(node) => tree.split(node, mtry, &mut visitor_queue, &mut rng),
                 None => break,
@@ -704,14 +703,17 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 count[visitor.y[i]] += visitor.samples[i];
             }
         }
+        
+        let parameters = self.parameters().expect("parameters not set — model not fitted");
+        let parameters_min_samples_split = parameters.min_samples_split;
 
-        self.nodes[visitor.node].impurity = Some(impurity(&self.parameters().criterion, &count, n));
+        self.nodes[visitor.node].impurity = Some(impurity(&parameters.criterion, &count, n));
 
         if is_pure {
             return false;
         }
 
-        if n <= self.parameters().min_samples_split {
+        if n <= parameters_min_samples_split {
             return false;
         }
 
@@ -753,9 +755,10 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
 
                 let tc = true_count.iter().sum();
                 let fc = n - tc;
+                let parameters = self.parameters().expect("parameters not set — model not fitted");
 
-                if tc < self.parameters().min_samples_leaf
-                    || fc < self.parameters().min_samples_leaf
+                if tc < parameters.min_samples_leaf
+                    || fc < parameters.min_samples_leaf
                 {
                     prevx = Some(x_ij);
                     prevy = visitor.y[*i];
@@ -772,9 +775,9 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 let parent_impurity = self.nodes()[visitor.node].impurity.unwrap();
                 let gain = parent_impurity
                     - tc as f64 / n as f64
-                        * impurity(&self.parameters().criterion, &true_count, tc)
+                        * impurity(&parameters.criterion, &true_count, tc)
                     - fc as f64 / n as f64
-                        * impurity(&self.parameters().criterion, false_count, fc);
+                        * impurity(&parameters.criterion, false_count, fc);
 
                 if self.nodes()[visitor.node].split_score.is_none()
                     || gain > self.nodes()[visitor.node].split_score.unwrap()
@@ -824,8 +827,10 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 }
             }
         }
+        
+        let parameters = self.parameters().expect("parameters not set — model not fitted");
 
-        if tc < self.parameters().min_samples_leaf || fc < self.parameters().min_samples_leaf {
+        if tc < parameters.min_samples_leaf || fc < parameters.min_samples_leaf {
             self.nodes[visitor.node].split_feature = 0;
             self.nodes[visitor.node].split_value = Option::None;
             self.nodes[visitor.node].split_score = Option::None;
@@ -1239,5 +1244,51 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&tree).unwrap()).unwrap();
 
         assert_eq!(tree, deserialized_tree);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters = DecisionTreeClassifierParameters::default();
+        let expected_parameters = parameters.clone();
+        let classifier =
+            DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+
+        let actual_parameters = classifier
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.criterion),
+            std::mem::discriminant(&expected_parameters.criterion)
+        );
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
+        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0, 0, 1, 1];
+        let parameters = DecisionTreeClassifierParameters::default();
+        let mut classifier =
+            DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+                &matrix,
+                &target,
+                parameters,
+            )
+            .unwrap();
+        classifier.parameters = None;
+
+        assert!(classifier.parameters().is_none());
     }
 }

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -618,7 +618,13 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
             visitor_queue.push_back(visitor);
         }
 
-        while tree.depth() < tree.parameters().expect("parameters not set — model not fitted").max_depth.unwrap_or(u16::MAX) {
+        while tree.depth()
+            < tree
+                .parameters()
+                .expect("parameters not set — model not fitted")
+                .max_depth
+                .unwrap_or(u16::MAX)
+        {
             match visitor_queue.pop_front() {
                 Some(node) => tree.split(node, mtry, &mut visitor_queue, &mut rng),
                 None => break,
@@ -703,8 +709,10 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 count[visitor.y[i]] += visitor.samples[i];
             }
         }
-        
-        let parameters = self.parameters().expect("parameters not set — model not fitted");
+
+        let parameters = self
+            .parameters()
+            .expect("parameters not set — model not fitted");
         let parameters_min_samples_split = parameters.min_samples_split;
 
         self.nodes[visitor.node].impurity = Some(impurity(&parameters.criterion, &count, n));
@@ -755,11 +763,11 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
 
                 let tc = true_count.iter().sum();
                 let fc = n - tc;
-                let parameters = self.parameters().expect("parameters not set — model not fitted");
+                let parameters = self
+                    .parameters()
+                    .expect("parameters not set — model not fitted");
 
-                if tc < parameters.min_samples_leaf
-                    || fc < parameters.min_samples_leaf
-                {
+                if tc < parameters.min_samples_leaf || fc < parameters.min_samples_leaf {
                     prevx = Some(x_ij);
                     prevy = visitor.y[*i];
                     true_count[visitor.y[*i]] += visitor.samples[*i];
@@ -774,10 +782,8 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 let false_label = which_max(false_count);
                 let parent_impurity = self.nodes()[visitor.node].impurity.unwrap();
                 let gain = parent_impurity
-                    - tc as f64 / n as f64
-                        * impurity(&parameters.criterion, &true_count, tc)
-                    - fc as f64 / n as f64
-                        * impurity(&parameters.criterion, false_count, fc);
+                    - tc as f64 / n as f64 * impurity(&parameters.criterion, &true_count, tc)
+                    - fc as f64 / n as f64 * impurity(&parameters.criterion, false_count, fc);
 
                 if self.nodes()[visitor.node].split_score.is_none()
                     || gain > self.nodes()[visitor.node].split_score.unwrap()
@@ -827,8 +833,10 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
                 }
             }
         }
-        
-        let parameters = self.parameters().expect("parameters not set — model not fitted");
+
+        let parameters = self
+            .parameters()
+            .expect("parameters not set — model not fitted");
 
         if tc < parameters.min_samples_leaf || fc < parameters.min_samples_leaf {
             self.nodes[visitor.node].split_feature = 0;
@@ -1245,7 +1253,7 @@ mod tests {
 
         assert_eq!(tree, deserialized_tree);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -1253,13 +1261,10 @@ mod tests {
         let target = vec![0, 0, 1, 1];
         let parameters = DecisionTreeClassifierParameters::default();
         let expected_parameters = parameters.clone();
-        let classifier =
-            DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let classifier = DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
 
         let actual_parameters = classifier
             .parameters()
@@ -1269,8 +1274,14 @@ mod tests {
             std::mem::discriminant(&expected_parameters.criterion)
         );
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
-        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(
+            actual_parameters.min_samples_leaf,
+            expected_parameters.min_samples_leaf
+        );
+        assert_eq!(
+            actual_parameters.min_samples_split,
+            expected_parameters.min_samples_split
+        );
         assert_eq!(actual_parameters.seed, expected_parameters.seed);
     }
 
@@ -1280,13 +1291,10 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0, 0, 1, 1];
         let parameters = DecisionTreeClassifierParameters::default();
-        let mut classifier =
-            DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
-                &matrix,
-                &target,
-                parameters,
-            )
-            .unwrap();
+        let mut classifier = DecisionTreeClassifier::<f64, i32, DenseMatrix<f64>, Vec<i32>>::fit(
+            &matrix, &target, parameters,
+        )
+        .unwrap();
         classifier.parameters = None;
 
         assert!(classifier.parameters().is_none());

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -94,6 +94,7 @@ pub struct DecisionTreeRegressorParameters {
 pub struct DecisionTreeRegressor<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 {
     tree_regressor: Option<BaseTreeRegressor<TX, TY, X, Y>>,
+    parameters: Option<DecisionTreeRegressorParameters>
 }
 
 impl DecisionTreeRegressorParameters {
@@ -271,7 +272,8 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 {
     fn new() -> Self {
         Self {
-            tree_regressor: None,
+            tree_regressor: Option::None,
+            parameters: Option::None
         }
     }
 
@@ -309,6 +311,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         let tree = BaseTreeRegressor::fit(x, y, tree_parameters)?;
         Ok(Self {
             tree_regressor: Some(tree),
+            parameters: Some(parameters)
         })
     }
 
@@ -316,6 +319,15 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     /// * `x` - _KxM_ data where _K_ is number of observations and _M_ is number of features.
     pub fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.tree_regressor.as_ref().unwrap().predict(x)
+    }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &DecisionTreeRegressorParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
     }
 }
 

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -324,10 +324,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &DecisionTreeRegressorParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&DecisionTreeRegressorParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -477,5 +476,45 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&tree).unwrap()).unwrap();
 
         assert_eq!(tree, deserialized_tree);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = DecisionTreeRegressorParameters::default();
+        let expected_parameters = parameters.clone();
+        let regressor = DecisionTreeRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
+        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = DecisionTreeRegressorParameters::default();
+        let mut regressor = DecisionTreeRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -94,7 +94,7 @@ pub struct DecisionTreeRegressorParameters {
 pub struct DecisionTreeRegressor<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
 {
     tree_regressor: Option<BaseTreeRegressor<TX, TY, X, Y>>,
-    parameters: Option<DecisionTreeRegressorParameters>
+    parameters: Option<DecisionTreeRegressorParameters>,
 }
 
 impl DecisionTreeRegressorParameters {
@@ -273,7 +273,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     fn new() -> Self {
         Self {
             tree_regressor: Option::None,
-            parameters: Option::None
+            parameters: Option::None,
         }
     }
 
@@ -311,7 +311,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         let tree = BaseTreeRegressor::fit(x, y, tree_parameters)?;
         Ok(Self {
             tree_regressor: Some(tree),
-            parameters: Some(parameters)
+            parameters: Some(parameters),
         })
     }
 
@@ -320,7 +320,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
     pub fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.tree_regressor.as_ref().unwrap().predict(x)
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -477,7 +477,7 @@ mod tests {
 
         assert_eq!(tree, deserialized_tree);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -486,9 +486,7 @@ mod tests {
         let parameters = DecisionTreeRegressorParameters::default();
         let expected_parameters = parameters.clone();
         let regressor = DecisionTreeRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
 
@@ -496,8 +494,14 @@ mod tests {
             .parameters()
             .expect("parameters should be set after fitting");
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.min_samples_leaf, expected_parameters.min_samples_leaf);
-        assert_eq!(actual_parameters.min_samples_split, expected_parameters.min_samples_split);
+        assert_eq!(
+            actual_parameters.min_samples_leaf,
+            expected_parameters.min_samples_leaf
+        );
+        assert_eq!(
+            actual_parameters.min_samples_split,
+            expected_parameters.min_samples_split
+        );
         assert_eq!(actual_parameters.seed, expected_parameters.seed);
     }
 
@@ -508,9 +512,7 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = DecisionTreeRegressorParameters::default();
         let mut regressor = DecisionTreeRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
+            &matrix, &target, parameters,
         )
         .unwrap();
         regressor.parameters = None;

--- a/src/xgboost/xgb_regressor.rs
+++ b/src/xgboost/xgb_regressor.rs
@@ -609,6 +609,15 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>> XGRegres
         indices.truncate((population_size as f64 * subsample_ratio) as usize);
         indices
     }
+    
+    /// Getter for parameters used in the model
+    ///
+    /// # Returns
+    /// Parameters used to setup the model
+    pub fn parameters(&self) -> &XGRegressorParameters {
+        assert!(self.parameters.is_some());
+        &self.parameters.as_ref().unwrap()
+    }
 }
 
 // Boilerplate implementation for the smartcore traits

--- a/src/xgboost/xgb_regressor.rs
+++ b/src/xgboost/xgb_regressor.rs
@@ -609,7 +609,7 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>> XGRegres
         indices.truncate((population_size as f64 * subsample_ratio) as usize);
         indices
     }
-    
+
     /// Getter for parameters used in the model
     ///
     /// # Returns
@@ -805,7 +805,7 @@ mod tests {
         let predictions = predict_result.unwrap();
         assert_eq!(predictions.len(), 4);
     }
-    
+
     #[test]
     fn test_can_get_assigned_parameters() {
         let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
@@ -813,20 +813,26 @@ mod tests {
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = XGRegressorParameters::default();
         let expected_parameters = parameters.clone();
-        let regressor = XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let regressor =
+            XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
 
         let actual_parameters = regressor
             .parameters()
             .expect("parameters should be set after fitting");
-        assert_eq!(actual_parameters.n_estimators, expected_parameters.n_estimators);
+        assert_eq!(
+            actual_parameters.n_estimators,
+            expected_parameters.n_estimators
+        );
         assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
-        assert_eq!(actual_parameters.learning_rate, expected_parameters.learning_rate);
-        assert_eq!(actual_parameters.min_child_weight, expected_parameters.min_child_weight);
+        assert_eq!(
+            actual_parameters.learning_rate,
+            expected_parameters.learning_rate
+        );
+        assert_eq!(
+            actual_parameters.min_child_weight,
+            expected_parameters.min_child_weight
+        );
         assert_eq!(actual_parameters.lambda, expected_parameters.lambda);
         assert_eq!(actual_parameters.gamma, expected_parameters.gamma);
         assert_eq!(actual_parameters.base_score, expected_parameters.base_score);
@@ -844,12 +850,9 @@ mod tests {
         let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
         let target = vec![0.0, 1.0, 1.0, 2.0];
         let parameters = XGRegressorParameters::default();
-        let mut regressor = XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
-            &matrix,
-            &target,
-            parameters,
-        )
-        .unwrap();
+        let mut regressor =
+            XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(&matrix, &target, parameters)
+                .unwrap();
         regressor.parameters = None;
 
         assert!(regressor.parameters().is_none());

--- a/src/xgboost/xgb_regressor.rs
+++ b/src/xgboost/xgb_regressor.rs
@@ -613,10 +613,9 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>> XGRegres
     /// Getter for parameters used in the model
     ///
     /// # Returns
-    /// Parameters used to setup the model
-    pub fn parameters(&self) -> &XGRegressorParameters {
-        assert!(self.parameters.is_some());
-        &self.parameters.as_ref().unwrap()
+    /// `Some` with the parameters used to configure the model, or `None` if unavailable.
+    pub fn parameters(&self) -> Option<&XGRegressorParameters> {
+        self.parameters.as_ref()
     }
 }
 
@@ -805,5 +804,54 @@ mod tests {
 
         let predictions = predict_result.unwrap();
         assert_eq!(predictions.len(), 4);
+    }
+    
+    #[test]
+    fn test_can_get_assigned_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = XGRegressorParameters::default();
+        let expected_parameters = parameters.clone();
+        let regressor = XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+
+        let actual_parameters = regressor
+            .parameters()
+            .expect("parameters should be set after fitting");
+        assert_eq!(actual_parameters.n_estimators, expected_parameters.n_estimators);
+        assert_eq!(actual_parameters.max_depth, expected_parameters.max_depth);
+        assert_eq!(actual_parameters.learning_rate, expected_parameters.learning_rate);
+        assert_eq!(actual_parameters.min_child_weight, expected_parameters.min_child_weight);
+        assert_eq!(actual_parameters.lambda, expected_parameters.lambda);
+        assert_eq!(actual_parameters.gamma, expected_parameters.gamma);
+        assert_eq!(actual_parameters.base_score, expected_parameters.base_score);
+        assert_eq!(actual_parameters.subsample, expected_parameters.subsample);
+        assert_eq!(actual_parameters.seed, expected_parameters.seed);
+        assert_eq!(
+            std::mem::discriminant(&actual_parameters.objective),
+            std::mem::discriminant(&expected_parameters.objective)
+        );
+    }
+
+    #[test]
+    fn test_returns_none_on_no_parameters() {
+        let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let matrix = DenseMatrix::new(4, 2, data, false).unwrap();
+        let target = vec![0.0, 1.0, 1.0, 2.0];
+        let parameters = XGRegressorParameters::default();
+        let mut regressor = XGRegressor::<f64, f64, DenseMatrix<f64>, Vec<f64>>::fit(
+            &matrix,
+            &target,
+            parameters,
+        )
+        .unwrap();
+        regressor.parameters = None;
+
+        assert!(regressor.parameters().is_none());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/smartcorelib/smartcore/issues/378

### Current behaviour

Several fitted models do not expose the hyperparameters that were used to create or train them.

After a model is fitted, and especially after it is serialized and deserialized, users can inspect learned model state such as coefficients, intercepts, trees, classes, or other fitted attributes where available, but the original training parameters are not consistently accessible from the model instance.

This makes it difficult to:

* inspect a loaded model’s configuration,
* debug model behavior after deserialization,
* log model metadata,
* reproduce training settings,
* compare two fitted models,
* and verify that a loaded model was trained with the expected hyperparameters.

### The follow-up changes in this revision:

* fix the Clippy failure caused by cloning a `Copy` parameter value;
* document the serialization limitation of borrowed `SVC` parameters;
* add `MultiClassSVC::parameters()` for API consistency;
* explain why the affected generic parameter types use manual Serde implementations; and
* remove synthetic tests that only forced private `parameters` fields to `None`, while retaining positive fit/getter coverage and a real SVC serialization test.
* Documents that `SVC::parameters()` returns `None` after deserialization because the fitted model stores a borrowed parameter reference.
* Retains the previously introduced public `SVCParameters::seed` field and public `DecisionTreeClassifier::parameters()` accessor

### New expected behaviour

Fitted models expose a public `.parameters()` getter that returns the hyperparameters used to create or train the model.

The getter provides read-only access to the model’s parameter struct, allowing users to inspect model configuration after fitting and after deserialization where the parameters are stored with the model.

This improves model reproducibility, auditability, debugging, and experiment tracking without requiring users to separately persist parameter structs outside the model.

### Change logs

#### Added
* Added public .parameters() getter methods to fitted model types that store their training hyperparameters.
* Added or updated parameter storage on fitted models where needed so the original training parameters can be inspected after fitting.
* Added support for retrieving model hyperparameters after deserialization where applicable.
* Added parameter round-trip tests that verify the values returned by .parameters() match the values supplied during fitting.

#### Changed
* Exposed DecisionTreeClassifier::parameters() as a public method.
* Exposed SVCParameters::seed as a public field.
* Created custom Deserialize implementation to support deserialization without requiring Default to the public API.

## Behavior and design decisions with borrows

### `SVC` serialization

`SVC` stores its fitted parameters as a borrowed reference:

```rust
parameters: Option<&'a SVCParameters<TX, TY, X, Y>>,
```

Serde cannot reconstruct that borrow, so the field remains skipped during serialization. The `SVC::parameters()` documentation now states explicitly that a deserialized `SVC` returns `None`, and the Serde round-trip test verifies that behavior. Added an assert to the test to expect a `None`.

This revision intentionally does **not** clone `SVCParameters` into the fitted model. Keeping the existing borrowed design avoids adding clone bounds, and potentially non-trivial kernel cloning to the SVM implementation solely for parameter introspection. 

### `MultiClassSVC`

`MultiClassSVC::parameters()` now exposes the parameter value shared by its one-vs-one binary classifiers. All classifiers are fitted from the same borrowed `SVCParameters`, so the getter returns the reference stored by the first fitted classifier. It returns `None` for an unfitted or empty model.

### Manual Serde implementations

The manual `Deserialize` implementations include a maintenance comment explaining that they avoid the implicit `Default` bounds that `#[derive(Deserialize)]` would add to generic parameter types.

The implementations are in:
* `DBSCANParameters<T, D>`
* `LogisticRegressionParameters<T>`
* `BernoulliNBParameters<T>`
* `KNNClassifierParameters<T, D>`
* `KNNRegressorParameters<T, D>`

### Public model coverage

#### Cluster

* [x] `AgglomerativeClustering`
* [x] `DBSCAN`
* [x] `KMeans`

#### Decomposition

* [x] `PCA`
* [x] `SVD`

#### Ensemble

* [x] `ExtraTreesRegressor`
* [x] `RandomForestClassifier`
* [x] `RandomForestRegressor`

#### Linear

* [x] `ElasticNet`
* [x] `Lasso`
* [x] `LinearRegression`
* [x] `LogisticRegression`
* [x] `RidgeRegression`

#### Naive Bayes

* [x] `BernoulliNB`
* [x] `CategoricalNB`
* [x] `GaussianNB`
* [x] `MultinomialNB`

#### Neighbors

* [x] `KNNClassifier`
* [x] `KNNRegressor`

#### SVM

* [x] `SVC` (Borrowed)
* [x] `MultiClassSVC` (Borrowed)
* [x] `SVR` (Borrowed)

#### Tree

* [x] `DecisionTreeClassifier`
* [x] `DecisionTreeRegressor`

#### XGBoost

* [x] `XGRegressor`
