### PR TITLE
docs: document Cargo.toml features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,27 @@ ordered-float = "5.1.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 typetag = { version = "0.2", optional = true }
 
+### FEATURES #################################################################
+
 [features]
 default = []
+
+# Enable serde Serialize/Deserialize for models and related types.
+# Also enables typetag on non-wasm targets for trait object serialization.
 serde = ["dep:serde", "dep:typetag"]
+
+# Optional bindings for the ndarray crate (DenseMatrix <-> ndarray).
 ndarray-bindings = ["dep:ndarray"]
+
+# Sample datasets (iris, boston, digits, ...) and dataset generators.
+# Enables std_rand and serde because datasets ship serialized bundles.
 datasets = ["std_rand", "serde"]
+
+# Use the standard library RNG (StdRng / thread_rng) instead of SmallRng.
+# Required for non-deterministic seeding without an explicit seed.
 std_rand = ["rand/std_rng", "rand/std", "rand/thread_rng"]
-# used by wasm32-unknown-unknown for in-browser usage
+
+# Enable getrandom's wasm_js backend for wasm32-unknown-unknown (in-browser).
 js = ["getrandom/wasm_js"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ ordered-float = "5.1.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 typetag = { version = "0.2", optional = true }
 
-### FEATURES #################################################################
-
 [features]
+# No features enabled by default; keeps the build WASM-compatible
+# and avoids pulling in serde/rand unless explicitly requested.
 default = []
 
 # Enable serde Serialize/Deserialize for models and related types.


### PR DESCRIPTION
## Problem
Optional features in `Cargo.toml` had little or no description, so users had to dig through source or README to learn what each flag enables. Issue #68 asked for serde-style feature documentation, including the missing `serde` feature note.

## Change
Document every feature in `Cargo.toml` with short comments in the style of [serde's Cargo.toml](https://github.com/serde-rs/serde/blob/master/serde/Cargo.toml):

- `default` - empty (WASM-friendly defaults)
- `serde` - Serialize/Deserialize for models; enables typetag on non-wasm
- `ndarray-bindings` - optional ndarray DenseMatrix bindings
- `datasets` - sample datasets and generators (pulls in `std_rand` + `serde`)
- `std_rand` - StdRng / thread_rng instead of SmallRng
- `js` - getrandom wasm_js backend for browser builds

Feature names were checked against `cfg(feature = ...)` usage in the crate (`serde`, `datasets`, `ndarray-bindings`, `std_rand`, `js`).

## Test plan
- [x] `cargo metadata --no-deps` parses features successfully
- [x] Confirmed feature names match cfg gates in source
- Docs-only change; no code behavior change

Fixes #68