### PR TITLE
test: replace unmaintained bincode with postcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ wasm-bindgen-test = "0.3"
 [dev-dependencies]
 itertools = "0.15.0"
 serde_json = "1.0"
-bincode = "1.3.1"
+postcard = { version = "1.1", features = ["use-std"] }
 
 [workspace]
 

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -805,7 +805,7 @@ mod tests {
         let forest = RandomForestClassifier::fit(&x, &y, Default::default()).unwrap();
 
         let deserialized_forest: RandomForestClassifier<f64, i64, DenseMatrix<f64>, Vec<i64>> =
-            bincode::deserialize(&bincode::serialize(&forest).unwrap()).unwrap();
+            postcard::from_bytes(&postcard::to_allocvec(&forest).unwrap()).unwrap();
 
         assert_eq!(forest, deserialized_forest);
     }

--- a/src/ensemble/random_forest_regressor.rs
+++ b/src/ensemble/random_forest_regressor.rs
@@ -608,7 +608,7 @@ mod tests {
         let forest = RandomForestRegressor::fit(&x, &y, Default::default()).unwrap();
 
         let deserialized_forest: RandomForestRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>> =
-            bincode::deserialize(&bincode::serialize(&forest).unwrap()).unwrap();
+            postcard::from_bytes(&postcard::to_allocvec(&forest).unwrap()).unwrap();
 
         assert_eq!(forest, deserialized_forest);
     }

--- a/src/neighbors/knn_classifier.rs
+++ b/src/neighbors/knn_classifier.rs
@@ -721,7 +721,7 @@ mod tests {
         let y = vec![2, 2, 2, 3, 3];
 
         let knn = KNNClassifier::fit(&x, &y, Default::default()).unwrap();
-        let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
+        let deserialized_knn = postcard::from_bytes(&postcard::to_allocvec(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
     }

--- a/src/neighbors/knn_regressor.rs
+++ b/src/neighbors/knn_regressor.rs
@@ -346,7 +346,7 @@ mod tests {
 
         let knn = KNNRegressor::fit(&x, &y, Default::default()).unwrap();
 
-        let deserialized_knn = bincode::deserialize(&bincode::serialize(&knn).unwrap()).unwrap();
+        let deserialized_knn = postcard::from_bytes(&postcard::to_allocvec(&knn).unwrap()).unwrap();
 
         assert_eq!(knn, deserialized_knn);
     }

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -1223,7 +1223,7 @@ mod tests {
         let tree = DecisionTreeClassifier::fit(&x, &y, Default::default()).unwrap();
 
         let deserialized_tree: DecisionTreeClassifier<f64, i64, DenseMatrix<f64>, Vec<i64>> =
-            bincode::deserialize(&bincode::serialize(&tree).unwrap()).unwrap();
+            postcard::from_bytes(&postcard::to_allocvec(&tree).unwrap()).unwrap();
 
         assert_eq!(tree, deserialized_tree);
     }

--- a/src/tree/decision_tree_regressor.rs
+++ b/src/tree/decision_tree_regressor.rs
@@ -462,7 +462,7 @@ mod tests {
         let tree = DecisionTreeRegressor::fit(&x, &y, Default::default()).unwrap();
 
         let deserialized_tree: DecisionTreeRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>> =
-            bincode::deserialize(&bincode::serialize(&tree).unwrap()).unwrap();
+            postcard::from_bytes(&postcard::to_allocvec(&tree).unwrap()).unwrap();
 
         assert_eq!(tree, deserialized_tree);
     }


### PR DESCRIPTION
bincode has been abandoned and its final 3.0.0 release is a poison pill whose entire source is `compile_error!("https://xkcd.com/2347/")`, which breaks any project Dependabot bumps to it.

bincode was a dev-dependency only, used for serde round-trip assertions in six model tests. Swap it for postcard: actively maintained, no_std + alloc, wasm-friendly, and a pure serde format so the migration is mechanical.

The SVM tests stay on serde_json. postcard is not self-describing and so cannot deserialize the `typetag::serde` trait objects those models use. Keeping both formats is deliberate: JSON alone would silently accept `#[serde(flatten)]`/`untagged` additions that break every binary format users actually persist models with.

Closes #377

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [ ] My branch is up-to-date with development branch.
- [ ] Everything works and tested on latest stable Rust.
- [ ] Coverage and Linting have been applied 

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
