### PR TITLE
ci: run smartcore-benches against release commit (#407)

### DIFF
--- a/.github/workflows/release-bench.yml
+++ b/.github/workflows/release-bench.yml
@@ -1,0 +1,73 @@
+name: Release benchmarks
+
+# When a release is published, clone smartcore-benches into the runner and
+# run its criterion + iai-callgrind harness against the released smartcore
+# code (which is already checked out at the release commit SHA). A
+# `[patch.crates-io]` override in a temporary `.cargo/config.toml` repoints
+# the benches' `smartcore = "0.6"` dependency to the local checkout, so no
+# crates.io round-trip or cross-repo dispatch is needed.
+# See https://github.com/smartcorelib/smartcore/issues/407
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smartcore (release commit)
+        uses: actions/checkout@v4
+
+      - name: Checkout smartcore-benches (sibling directory)
+        uses: actions/checkout@v4
+        with:
+          repository: smartcorelib/smartcore-benches
+          path: smartcore-benches
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Valgrind (for iai-callgrind)
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Cache .cargo and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            ./smartcore-benches/target
+          key: release-bench-${{ hashFiles('Cargo.toml', 'smartcore-benches/Cargo.toml') }}
+          restore-keys: release-bench-
+
+      - name: Patch benches to use local smartcore
+        run: |
+          mkdir -p smartcore-benches/.cargo
+          cat > smartcore-benches/.cargo/config.toml <<'CFG'
+          [patch.crates-io]
+          smartcore = { path = "../" }
+          CFG
+
+      - name: Build benches (no-run)
+        working-directory: smartcore-benches
+        run: cargo bench --no-run
+
+      - name: Run criterion benchmarks
+        working-directory: smartcore-benches
+        run: |
+          mkdir -p bench-output
+          cargo bench -- --output-format bencher | tee bench-output/criterion.json
+
+      - name: Run iai-callgrind benchmarks
+        working-directory: smartcore-benches
+        run: |
+          for bench in iai_matmul iai_ab iai_svd iai_cover_tree iai_iterator_mut; do
+            cargo bench --bench "$bench" -- --save-baseline=release 2>&1 | tee "bench-output/${bench}.json" || true
+          done
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-benchmark-results
+          path: smartcore-benches/bench-output/
+          retention-days: 90


### PR DESCRIPTION
## Summary

Adds a dedicated CI workflow that clones `smartcore-benches` into the runner and runs its criterion + iai-callgrind benchmarks against the released smartcore code — all in-repo, no cross-repo dispatch or PAT needed. Scoped to releases per the focused ask (#407).

## Changes

- **New file**: `.github/workflows/release-bench.yml`
  - Triggers `on: release: types: [published]`
  - Checks out smartcore (at the release commit) + smartcore-benches (into a sibling `smartcore-benches/` directory)
  - Creates a temporary `.cargo/config.toml` with `[patch.crates-io] smartcore = { path = "../" }` so the benches' `smartcore = "0.6"` dependency resolves to the local checkout instead of crates.io
  - Installs Valgrind (for iai-callgrind)
  - Builds benches (`cargo bench --no-run`)
  - Runs criterion benchmarks (`--output-format bencher` → `bench-output/criterion.json`)
  - Runs iai-callgrind benches (per-bench: `iai_matmul`, `iai_ab`, `iai_svd`, `iai_cover_tree`, `iai_iterator_mut`)
  - Uploads all results as artifacts (`release-benchmark-results`, 90-day retention)

## No secrets, no PAT, no cross-repo dispatch

The benches run directly in the smartcore CI runner. The `[patch.crates-io]` override repoints the benches' smartcore dependency to the already-checked-out release commit — no crates.io round-trip, no `repository_dispatch`, no `BENCHES_DISPATCH_PAT` secret.

## Verification

- `cargo fmt --all -- --check` = 0
- `cargo clippy --all-features -- -Drust-2018-idioms -Drust-2024-compatibility -Dwarnings` = 0
- YAML valid; pre-commit hook passed (fmt + clippy)

## What this does NOT do (intentionally, per scope)

- Does **not** trigger benches on `development` pushes — that's the per-commit dispatch path (separate concern).
- Does **not** add iai-callgrind as a required branch-protection gate — that comes after a baseline is established.

Refs #407.
