### PR TITLE
test(stage-2): add proptest + linalg edge cases (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4]
+### Added
+- Stage 2 test-coverage push (#393): `proptest` dev-dependency + property-based invariant tests and linalg edge cases.
+  - `linalg/basic/arrays.rs`: proptest invariants — transpose involution `(A^T)^T == A`, matmul with identity `A*I == A`, matmul associativity `(AB)C ≈ A(BC)` (approximate comparison for FP), `(AB)^T == B^T A^T`, reshape preserves element count. Edge cases — 1x1 matmul, row×col matmul, shape-mismatch panic, reshape-incompatible panic, 1xN transpose.
+  - `algorithm/sort/quick_sort.rs`: proptest — `quick_argsort` produces a valid permutation (all indices present exactly once, values non-decreasing in permutation order).
+  - `metrics/distance/euclidian.rs`: proptest — `d(a,a) == 0`, symmetry `d(a,b) == d(b,a)`, triangle inequality `d(a,c) ≤ d(a,b) + d(b,c)`.
+
+### Changed
+- Added `proptest = "1.5"` to `[dev-dependencies]`.
+
 ## [0.6.3]
 ### Changed
 - Replaced the remaining 4 `unsafe {}` raw-pointer blocks in `linalg/basic/matrix.rs::iterator_mut` / `DenseMatrixMutView::iter_mut` with a safe `split_first_mut`-based helper `ordered_iter_mut` (#368). The traversal order and offset formula are identical to the previous raw-pointer implementation; only the borrow-proving mechanism changed — eliminating `unsafe` from library code entirely.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smartcore"
 description = "Machine Learning in Rust."
 homepage = "https://smartcorelib.org"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["smartcore Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -67,6 +67,7 @@ wasm-bindgen-test = "0.3"
 itertools = "0.15.0"
 serde_json = "1.0"
 postcard = { version = "1.1", features = ["use-std"] }
+proptest = "1.5"
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ wasm-bindgen-test = "0.3"
 itertools = "0.15.0"
 serde_json = "1.0"
 postcard = { version = "1.1", features = ["use-std"] }
+
+# proptest pulls in wait-timeout (Unix syscalls), which doesn't compile on
+# wasm32. Gate it to non-wasm targets only.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1.5"
 
 [workspace]

--- a/src/algorithm/sort/quick_sort.rs
+++ b/src/algorithm/sort/quick_sort.rs
@@ -135,4 +135,40 @@ mod tests {
             arr2.quick_argsort()
         );
     }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn quick_argsort_is_valid_permutation() {
+        use proptest::prelude::*;
+
+        proptest!(
+            |(arr in proptest::collection::vec(-100.0f64..100.0, 1..=20))|
+            {
+                let n = arr.len();
+                let perm = arr.quick_argsort();
+                prop_assert_eq!(perm.len(), n, "permutation length mismatch");
+
+                if n == 0 {
+                    return Ok(()); // trivially valid
+                }
+
+                // perm must be a permutation of 0..n
+                let mut seen = vec![false; n];
+                for &idx in &perm {
+                    prop_assert!(idx < n, "index {idx} out of range");
+                    prop_assert!(!std::mem::replace(&mut seen[idx], true),
+                        "index {idx} appears twice");
+                }
+
+                // the values visited in permutation order must be non-decreasing
+                for i in 1..n {
+                    prop_assert!(arr[perm[i - 1]] <= arr[perm[i]],
+                        "not sorted at position {i}");
+                }
+            }
+        );
+    }
 }

--- a/src/algorithm/sort/quick_sort.rs
+++ b/src/algorithm/sort/quick_sort.rs
@@ -141,6 +141,7 @@ mod tests {
         wasm_bindgen_test::wasm_bindgen_test
     )]
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn quick_argsort_is_valid_permutation() {
         use proptest::prelude::*;
 
@@ -150,10 +151,6 @@ mod tests {
                 let n = arr.len();
                 let perm = arr.quick_argsort();
                 prop_assert_eq!(perm.len(), n, "permutation length mismatch");
-
-                if n == 0 {
-                    return Ok(()); // trivially valid
-                }
 
                 // perm must be a permutation of 0..n
                 let mut seen = vec![false; n];

--- a/src/linalg/basic/arrays.rs
+++ b/src/linalg/basic/arrays.rs
@@ -2220,4 +2220,164 @@ mod tests {
         let sorted = view.argsort_mut();
         assert_eq!(sorted.len(), 1000);
     }
+
+    // ---- Stage 2: proptest invariants + edge cases ----
+
+    use proptest::prelude::*;
+
+    fn arb_small_matrix(max_dim: usize) -> impl Strategy<Value = DenseMatrix<f64>> {
+        (1..=max_dim, 1..=max_dim).prop_flat_map(|(r, c)| {
+            proptest::collection::vec(0.0f64..100.0, r * c)
+                .prop_map(move |vals| DenseMatrix::new(r, c, vals, false).unwrap())
+        })
+    }
+
+    fn make_identity(n: usize) -> DenseMatrix<f64> {
+        let mut vals = vec![0.0; n * n];
+        for i in 0..n {
+            vals[i * n + i] = 1.0;
+        }
+        DenseMatrix::new(n, n, vals, false).unwrap()
+    }
+
+    /// Transpose is an involution: (A^T)^T == A
+    #[test]
+    fn proptest_transpose_involution() {
+        proptest!(
+            |(a in arb_small_matrix(8))| {
+                let tt = a.transpose().transpose();
+                prop_assert_eq!(tt, a);
+            }
+        );
+    }
+
+    /// Matmul with an identity matrix is a no-op: A * I == A
+    #[test]
+    fn proptest_matmul_identity() {
+        proptest!(
+            |(a in arb_small_matrix(8))| {
+                let n = a.shape().1;
+                let identity = make_identity(n);
+                let result = a.matmul(&identity);
+                prop_assert_eq!(result, a);
+            }
+        );
+    }
+
+    /// Matmul associativity: (AB)C == A(BC) where shapes allow
+    #[test]
+    fn proptest_matmul_associativity() {
+        proptest!(
+            |(a_vals in proptest::collection::vec(-5.0f64..5.0, 6),
+              b_vals in proptest::collection::vec(-5.0f64..5.0, 12),
+              c_vals in proptest::collection::vec(-5.0f64..5.0, 12))|
+            {
+                // A: 2x3, B: 3x4, C: 4x3  (so (AB)C = 2x3, A(BC) = 2x3)
+                let a = DenseMatrix::new(2, 3, a_vals, false).unwrap();
+                let b = DenseMatrix::new(3, 4, b_vals, false).unwrap();
+                let c = DenseMatrix::new(4, 3, c_vals, false).unwrap();
+
+                let ab = a.matmul(&b);
+                let ab_c = ab.matmul(&c);
+
+                let bc = b.matmul(&c);
+                let a_bc = a.matmul(&bc);
+
+                // Use approximate comparison: floating-point accumulation
+                // across three matmils can cause exact PartialEq to fail.
+                let (r1, c1) = ab_c.shape();
+                let (r2, c2) = a_bc.shape();
+                prop_assert!(r1 == r2 && c1 == c2, "shape mismatch");
+                for i in 0..r1 {
+                    for j in 0..c1 {
+                        let diff = (ab_c.get((i, j)) - a_bc.get((i, j))).abs();
+                        prop_assert!(diff < 1e-9, "({i},{j}): diff={diff}");
+                    }
+                }
+            }
+        );
+    }
+
+    /// (AB)^T == B^T * A^T
+    #[test]
+    fn proptest_matmul_transpose_identity() {
+        proptest!(
+            |(a_vals in proptest::collection::vec(0.0f64..10.0, 6),
+              b_vals in proptest::collection::vec(0.0f64..10.0, 12))|
+            {
+                // A: 2x3, B: 3x4
+                let a = DenseMatrix::new(2, 3, a_vals, false).unwrap();
+                let b = DenseMatrix::new(3, 4, b_vals, false).unwrap();
+
+                let ab_t = a.matmul(&b).transpose();
+                let bt_at = b.transpose().matmul(&a.transpose());
+
+                prop_assert_eq!(ab_t, bt_at);
+            }
+        );
+    }
+
+    /// Reshape preserves total element count
+    #[test]
+    fn proptest_reshape_preserves_count() {
+        proptest!(
+            |(vals in proptest::collection::vec(0.0f64..50.0, 12),
+              factor in 1usize..=12)|
+            {
+                proptest::prop_assume!(12 % factor == 0);
+                let new_rows = factor;
+                let new_cols = 12 / factor;
+                let m = DenseMatrix::new(3, 4, vals, false).unwrap();
+                let reshaped = m.reshape(new_rows, new_cols, 0);
+                prop_assert_eq!(reshaped.shape(), (new_rows, new_cols));
+            }
+        );
+    }
+
+    /// Edge case: 1x1 matmul
+    #[test]
+    fn edge_matmul_1x1() {
+        let a = DenseMatrix::from_2d_array(&[&[5.0]]).unwrap();
+        let b = DenseMatrix::from_2d_array(&[&[3.0]]).unwrap();
+        let c = a.matmul(&b);
+        assert_eq!(c, DenseMatrix::from_2d_array(&[&[15.0]]).unwrap());
+    }
+
+    /// Edge case: matmul with a 1xN row vector times Nx1 column vector -> 1x1
+    #[test]
+    fn edge_matmul_row_times_col() {
+        let a = DenseMatrix::from_2d_array(&[&[1.0, 2.0, 3.0]]).unwrap();
+        let b = DenseMatrix::from_2d_array(&[&[4.0], &[5.0], &[6.0]]).unwrap();
+        let c = a.matmul(&b);
+        assert_eq!(c.shape(), (1, 1));
+        assert!((c.get((0, 0)) - 32.0).abs() < 1e-10);
+    }
+
+    /// Edge case: matmul shape mismatch should panic
+    #[test]
+    #[should_panic(expected = "Can't multiply")]
+    fn edge_matmul_shape_mismatch_panics() {
+        let a = DenseMatrix::from_2d_array(&[&[1.0, 2.0]]).unwrap();
+        let b = DenseMatrix::from_2d_array(&[&[1.0, 2.0]]).unwrap();
+        let _ = a.matmul(&b);
+    }
+
+    /// Edge case: reshape to incompatible size should panic
+    #[test]
+    #[should_panic(expected = "Can't reshape")]
+    fn edge_reshape_incompatible_panics() {
+        let a = DenseMatrix::from_2d_array(&[&[1.0, 2.0], &[3.0, 4.0]]).unwrap();
+        let _ = a.reshape(3, 1, 0);
+    }
+
+    /// Edge case: transpose of 1xN
+    #[test]
+    fn edge_transpose_1xn() {
+        let a = DenseMatrix::from_2d_array(&[&[1.0, 2.0, 3.0]]).unwrap();
+        let t = a.transpose();
+        assert_eq!(t.shape(), (3, 1));
+        assert_eq!(t.get((0, 0)), &1.0);
+        assert_eq!(t.get((1, 0)), &2.0);
+        assert_eq!(t.get((2, 0)), &3.0);
+    }
 }

--- a/src/linalg/basic/arrays.rs
+++ b/src/linalg/basic/arrays.rs
@@ -2223,15 +2223,18 @@ mod tests {
 
     // ---- Stage 2: proptest invariants + edge cases ----
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_small_matrix(max_dim: usize) -> impl Strategy<Value = DenseMatrix<f64>> {
         (1..=max_dim, 1..=max_dim).prop_flat_map(|(r, c)| {
-            proptest::collection::vec(0.0f64..100.0, r * c)
+            proptest::collection::vec(-50.0f64..50.0, r * c)
                 .prop_map(move |vals| DenseMatrix::new(r, c, vals, false).unwrap())
         })
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn make_identity(n: usize) -> DenseMatrix<f64> {
         let mut vals = vec![0.0; n * n];
         for i in 0..n {
@@ -2241,6 +2244,7 @@ mod tests {
     }
 
     /// Transpose is an involution: (A^T)^T == A
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn proptest_transpose_involution() {
         proptest!(
@@ -2252,6 +2256,7 @@ mod tests {
     }
 
     /// Matmul with an identity matrix is a no-op: A * I == A
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn proptest_matmul_identity() {
         proptest!(
@@ -2265,6 +2270,7 @@ mod tests {
     }
 
     /// Matmul associativity: (AB)C == A(BC) where shapes allow
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn proptest_matmul_associativity() {
         proptest!(
@@ -2284,7 +2290,7 @@ mod tests {
                 let a_bc = a.matmul(&bc);
 
                 // Use approximate comparison: floating-point accumulation
-                // across three matmils can cause exact PartialEq to fail.
+                // across three matmuls can cause exact PartialEq to fail.
                 let (r1, c1) = ab_c.shape();
                 let (r2, c2) = a_bc.shape();
                 prop_assert!(r1 == r2 && c1 == c2, "shape mismatch");
@@ -2299,6 +2305,7 @@ mod tests {
     }
 
     /// (AB)^T == B^T * A^T
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn proptest_matmul_transpose_identity() {
         proptest!(
@@ -2312,12 +2319,20 @@ mod tests {
                 let ab_t = a.matmul(&b).transpose();
                 let bt_at = b.transpose().matmul(&a.transpose());
 
-                prop_assert_eq!(ab_t, bt_at);
+                // approximate comparison — FP accumulation can exceed exact PartialEq
+                let (r, c) = ab_t.shape();
+                for i in 0..r {
+                    for j in 0..c {
+                        let diff = (ab_t.get((i, j)) - bt_at.get((i, j))).abs();
+                        prop_assert!(diff < 1e-10, "({i},{j}): diff={diff}");
+                    }
+                }
             }
         );
     }
 
     /// Reshape preserves total element count
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn proptest_reshape_preserves_count() {
         proptest!(

--- a/src/metrics/distance/euclidian.rs
+++ b/src/metrics/distance/euclidian.rs
@@ -89,4 +89,64 @@ mod tests {
 
         assert!((l2 - 5.19615242).abs() < 1e-8);
     }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn euclidean_distance_zero_for_identical_points() {
+        use proptest::prelude::*;
+
+        proptest!(
+            |(a in proptest::collection::vec(-100.0f64..100.0, 1..=10))|
+            {
+                let dist: f64 = Euclidian::new().distance(&a, &a);
+                prop_assert!(dist.abs() < 1e-10, "d(a,a)={dist}");
+            }
+        );
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn euclidean_distance_symmetric() {
+        use proptest::prelude::*;
+
+        proptest!( |(len in 1usize..=10,
+                   a_vals in proptest::collection::vec(-100.0f64..100.0, 10),
+                   b_vals in proptest::collection::vec(-100.0f64..100.0, 10))| {
+            let a: Vec<f64> = a_vals[..len].to_vec();
+            let b: Vec<f64> = b_vals[..len].to_vec();
+            let d_ab: f64 = Euclidian::new().distance(&a, &b);
+            let d_ba: f64 = Euclidian::new().distance(&b, &a);
+            prop_assert!((d_ab - d_ba).abs() < 1e-10, "d(a,b)={}, d(b,a)={}", d_ab, d_ba);
+        });
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn euclidean_distance_triangle_inequality() {
+        use proptest::prelude::*;
+
+        proptest!( |(len in 1usize..=8,
+                   a_vals in proptest::collection::vec(-50.0f64..50.0, 8),
+                   b_vals in proptest::collection::vec(-50.0f64..50.0, 8),
+                   c_vals in proptest::collection::vec(-50.0f64..50.0, 8))| {
+            let a: Vec<f64> = a_vals[..len].to_vec();
+            let b: Vec<f64> = b_vals[..len].to_vec();
+            let c: Vec<f64> = c_vals[..len].to_vec();
+            let d_ab: f64 = Euclidian::new().distance(&a, &b);
+            let d_bc: f64 = Euclidian::new().distance(&b, &c);
+            let d_ac: f64 = Euclidian::new().distance(&a, &c);
+            prop_assert!(d_ac <= d_ab + d_bc + 1e-9,
+                "triangle inequality violated: d(a,c)={}, d(a,b)+d(b,c)={}",
+                d_ac, d_ab + d_bc);
+        });
+    }
 }

--- a/src/metrics/distance/euclidian.rs
+++ b/src/metrics/distance/euclidian.rs
@@ -90,10 +90,7 @@ mod tests {
         assert!((l2 - 5.19615242).abs() < 1e-8);
     }
 
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn euclidean_distance_zero_for_identical_points() {
         use proptest::prelude::*;
@@ -107,10 +104,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn euclidean_distance_symmetric() {
         use proptest::prelude::*;
@@ -126,10 +120,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn euclidean_distance_triangle_inequality() {
         use proptest::prelude::*;


### PR DESCRIPTION
## Summary

Stage 2 of #391, tracked in #393. Adds `proptest` as a dev-dependency and writes property-based invariant tests + edge cases for core linalg, sort, and distance. +14 tests (474 → 488 unit), all gates green.

## Changes

### `proptest = "1.5"` added to `[dev-dependencies]`

### `linalg/basic/arrays.rs` — 5 proptest invariants + 5 edge cases
- **Transpose involution**: `(A^T)^T == A`
- **Matmul identity**: `A * I == A`
- **Matmul associativity**: `(AB)C ≈ A(BC)` (approximate comparison — FP accumulation across three matmuls can exceed exact `PartialEq`)
- **Transpose-matmul identity**: `(AB)^T == B^T * A^T`
- **Reshape preserves element count**: reshaped matrix has the expected `(rows, cols)` shape
- Edge: 1×1 matmul, row×col matmul (→ 1×1), shape-mismatch panic, reshape-incompatible panic, 1×N transpose

### `algorithm/sort/quick_sort.rs` — 1 proptest invariant
- **Valid permutation**: `quick_argsort` produces a permutation where all indices appear exactly once and values are non-decreasing in permutation order

### `metrics/distance/euclidian.rs` — 3 proptest invariants
- **Zero for identical points**: `d(a, a) == 0`
- **Symmetry**: `d(a, b) == d(b, a)`
- **Triangle inequality**: `d(a, c) ≤ d(a, b) + d(b, c)`

## Verification (run, not guessed)

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --all-features -- -Drust-2018-idioms -Drust-2024-compatibility -Dwarnings` | exit 0 |
| `cargo test --all-features` | exit 0 — 488 unit, 68+3 doctests |

## Notes

- Matmul associativity uses approximate comparison (1e-9 tolerance) because three-level FP accumulation can cause exact `PartialEq` to fail — discovered by running, not guessing.
- Distance proptests generate same-length vectors via a shared `len` parameter (the `distance` function panics on size mismatch).
- Each batch was verified by running before moving to the next.

Version bumped `0.6.3` → `0.6.4`; CHANGELOG updated under `[0.6.4]`.

Closes #393.
