### PR TITLE
refactor(naive_bayes): remove duplicated RealNumber trait bound

### DIFF
--- a/src/naive_bayes/gaussian.rs
+++ b/src/naive_bayes/gaussian.rs
@@ -260,7 +260,7 @@ impl<TY: Number + Ord + Unsigned> GaussianNBDistribution<TY> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
 pub struct GaussianNB<
-    TX: Number + RealNumber + RealNumber,
+    TX: Number + RealNumber,
     TY: Number + Ord + Unsigned,
     X: Array2<TX>,
     Y: Array1<TY>,
@@ -268,12 +268,8 @@ pub struct GaussianNB<
     inner: Option<BaseNaiveBayes<TX, TY, X, Y, GaussianNBDistribution<TY>>>,
 }
 
-impl<
-    TX: Number + RealNumber + RealNumber,
-    TY: Number + Ord + Unsigned,
-    X: Array2<TX>,
-    Y: Array1<TY>,
-> fmt::Display for GaussianNB<TX, TY, X, Y>
+impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>>
+    fmt::Display for GaussianNB<TX, TY, X, Y>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "GaussianNB:\ninner: {:?}", self.inner.as_ref().unwrap())?;
@@ -281,12 +277,8 @@ impl<
     }
 }
 
-impl<
-    TX: Number + RealNumber + RealNumber,
-    TY: Number + Ord + Unsigned,
-    X: Array2<TX>,
-    Y: Array1<TY>,
-> SupervisedEstimator<X, Y, GaussianNBParameters> for GaussianNB<TX, TY, X, Y>
+impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>>
+    SupervisedEstimator<X, Y, GaussianNBParameters> for GaussianNB<TX, TY, X, Y>
 {
     fn new() -> Self {
         Self {
@@ -299,12 +291,8 @@ impl<
     }
 }
 
-impl<
-    TX: Number + RealNumber + RealNumber,
-    TY: Number + Ord + Unsigned,
-    X: Array2<TX>,
-    Y: Array1<TY>,
-> Predictor<X, Y> for GaussianNB<TX, TY, X, Y>
+impl<TX: Number + RealNumber, TY: Number + Ord + Unsigned, X: Array2<TX>, Y: Array1<TY>>
+    Predictor<X, Y> for GaussianNB<TX, TY, X, Y>
 {
     fn predict(&self, x: &X) -> Result<Y, Failed> {
         self.predict(x)


### PR DESCRIPTION
Fixes #424

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust. (rustc 1.97.1)
- [x] Coverage and Linting have been applied

### Current behaviour

`GaussianNB` asks for `TX: Number + RealNumber + RealNumber`. `RealNumber` is listed twice, and it happens in four places: the struct itself, plus its `Display`, `SupervisedEstimator` and `Predictor` impls.

Saying it twice doesn't ask anything extra of `TX`, so nothing is broken here. rustc compiles it without a word, and clippy has nothing to say about it either, which is presumably how it survived this long.

It looks like it crept in by accident. Three of the four came with the v0.4 generics rewrite (52eb6ce), where the old single `T: RealNumber` was split into `TX`/`TY`. The fourth was copy-pasted a few days later along with the new `Display` impl (ba70bb9).

### New expected behaviour

Just `TX: Number + RealNumber`. Same requirements on `TX`, same generated code, one less thing to read.

### Testing

No new tests, since there's no behaviour change to assert and no new code paths for coverage to reach. The existing `naive_bayes` tests still pass:

- `cargo build` — clean
- `cargo clippy --all-features -- -D warnings` — clean
- `cargo test naive_bayes` — 23 passed, 0 failed

### Change logs

#### Changed
- Removed the repeated `RealNumber` bound from `GaussianNB` and its `Display`, `SupervisedEstimator` and `Predictor` impls.
