### PR TITLE
fix(tests): Stage 5 feature-gated & cross-cutting tests (#396)

### DIFF
--- a/src/tests_stage5_datasets.rs
+++ b/src/tests_stage5_datasets.rs
@@ -1,0 +1,180 @@
+//! Stage 5: dataset loader & generator edge-case tests.
+//!
+//! Gated on `#[cfg(feature = "datasets")]`.
+//! Tracking issue: #396 / #391.
+
+#[cfg(all(test, feature = "datasets"))]
+mod dataset_tests {
+    // ── Loaders ──────────────────────────────────────────────────────────────
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn boston_loader_shape_and_features() {
+        use crate::dataset::boston::load_dataset;
+        let ds = load_dataset();
+        assert_eq!(ds.num_features, 13, "Boston: expected 13 features");
+        assert_eq!(ds.num_samples, 506, "Boston: expected 506 samples");
+        assert_eq!(ds.data.len(), 506 * 13);
+        assert_eq!(ds.target.len(), 506);
+        assert!(!ds.feature_names.is_empty(), "Boston: feature_names empty");
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn breast_cancer_loader_shape_and_binary_target() {
+        use crate::dataset::breast_cancer::load_dataset;
+        let ds = load_dataset();
+        assert_eq!(ds.num_features, 30, "BreastCancer: expected 30 features");
+        assert_eq!(ds.num_samples, 569, "BreastCancer: expected 569 samples");
+        // Target is binary: only 0s and 1s
+        let unique_targets: std::collections::HashSet<u32> = ds.target.iter().cloned().collect();
+        assert!(unique_targets.len() <= 2, "BreastCancer: more than 2 target classes");
+        assert!(unique_targets.contains(&0) || unique_targets.contains(&1));
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn diabetes_loader_shape() {
+        use crate::dataset::diabetes::load_dataset;
+        let ds = load_dataset();
+        assert_eq!(ds.num_features, 10, "Diabetes: expected 10 features");
+        assert_eq!(ds.num_samples, 442, "Diabetes: expected 442 samples");
+        assert_eq!(ds.data.len(), 442 * 10);
+        assert_eq!(ds.target.len(), 442);
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn digits_loader_shape_and_target_cardinality() {
+        use crate::dataset::digits::load_dataset;
+        let ds = load_dataset();
+        assert_eq!(ds.num_features, 64, "Digits: expected 64 features");
+        assert_eq!(ds.num_samples, 1797, "Digits: expected 1797 samples");
+        let unique_targets: std::collections::HashSet<u32> = ds.target.iter().cloned().collect();
+        assert_eq!(unique_targets.len(), 10, "Digits: expected 10 classes (0-9)");
+    }
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn iris_loader_shape_and_target_names() {
+        use crate::dataset::iris::load_dataset;
+        let ds = load_dataset();
+        assert_eq!(ds.num_features, 4, "Iris: expected 4 features");
+        assert_eq!(ds.num_samples, 150, "Iris: expected 150 samples");
+        assert_eq!(ds.feature_names.len(), 4);
+        assert_eq!(ds.target_names.len(), 3, "Iris: expected 3 target names");
+        let unique_targets: std::collections::HashSet<u32> = ds.target.iter().cloned().collect();
+        assert_eq!(unique_targets.len(), 3, "Iris: expected 3 target classes");
+    }
+
+    // ── Generators ───────────────────────────────────────────────────────────
+
+    use crate::dataset::generator::{make_blobs, make_circles, make_moons};
+
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_blobs_standard() {
+        let ds = make_blobs(100, 4, 3);
+        assert_eq!(ds.num_samples, 100);
+        assert_eq!(ds.num_features, 4);
+        assert_eq!(ds.data.len(), 400);
+        assert_eq!(ds.target.len(), 100);
+        // Labels should be in {0.0, 1.0, 2.0}
+        let unique: std::collections::HashSet<u32> =
+            ds.target.iter().map(|&v| v as u32).collect();
+        assert_eq!(unique.len(), 3);
+    }
+
+    /// n_samples=1 edge-case: must not panic.
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_blobs_single_sample() {
+        let ds = make_blobs(1, 2, 1);
+        assert_eq!(ds.num_samples, 1);
+        assert_eq!(ds.data.len(), 2);
+        assert_eq!(ds.target.len(), 1);
+    }
+
+    /// noise=0 circles: all data should be finite.
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_circles_zero_noise() {
+        let ds = make_circles(20, 0.5, 0.0);
+        assert_eq!(ds.num_samples, 20);
+        assert_eq!(ds.num_features, 2);
+        assert!(ds.data.iter().all(|v| v.is_finite()), "non-finite value in circles data");
+    }
+
+    /// noise=0 moons: all data should be finite.
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_moons_zero_noise() {
+        let ds = make_moons(20, 0.0);
+        assert_eq!(ds.num_samples, 20);
+        assert_eq!(ds.num_features, 2);
+        assert!(ds.data.iter().all(|v| v.is_finite()), "non-finite value in moons data");
+    }
+
+    /// make_circles with n_samples=2 (minimum viable: 1 outer + 1 inner).
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_circles_minimal_samples() {
+        let ds = make_circles(2, 0.5, 0.01);
+        assert_eq!(ds.num_samples, 2);
+        assert_eq!(ds.target.len(), 2);
+    }
+
+    /// make_moons with n_samples=2.
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn make_moons_minimal_samples() {
+        let ds = make_moons(2, 0.0);
+        assert_eq!(ds.num_samples, 2);
+        assert_eq!(ds.target.len(), 2);
+    }
+
+    /// Description field is always non-empty.
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
+    #[test]
+    fn dataset_description_non_empty() {
+        assert!(!make_blobs(10, 2, 2).description.is_empty());
+        assert!(!make_circles(10, 0.5, 0.05).description.is_empty());
+        assert!(!make_moons(10, 0.05).description.is_empty());
+    }
+}

--- a/src/tests_stage5_ndarray.rs
+++ b/src/tests_stage5_ndarray.rs
@@ -1,0 +1,186 @@
+//! Stage 5: ndarray-bindings parity tests.
+//!
+//! Ensures `ArrayBase<OwnedRepr<T>, Ix2>` (ndarray) behaves identically to
+//! `DenseMatrix<T>` for all operations covered in `linalg/basic/`.
+//!
+//! Gated on `#[cfg(feature = "ndarray-bindings")]`.
+//! Tracking issue: #396 / #391.
+
+#[cfg(all(test, feature = "ndarray-bindings"))]
+mod ndarray_parity {
+    use crate::linalg::basic::arrays::{Array, Array2, ArrayView1, ArrayView2};
+    use crate::linalg::basic::matrix::DenseMatrix;
+    use ndarray::{arr2, Array2 as NdArray2};
+
+    fn assert_close_f64(a: f64, b: f64, tol: f64, label: &str) {
+        assert!((a - b).abs() < tol, "{label}: expected {b}, got {a}");
+    }
+
+    // ── shape ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_shape_parity() {
+        let nd: NdArray2<f64> = arr2(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        assert_eq!(Array::shape(&nd), Array::shape(&dm));
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_get_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        for r in 0..2 {
+            for c in 0..3 {
+                assert_eq!(
+                    Array::get(&nd, (r, c)),
+                    Array::get(&dm, (r, c)),
+                    "get({r},{c}) mismatch"
+                );
+            }
+        }
+    }
+
+    // ── is_empty ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_is_empty_parity() {
+        let empty_nd = NdArray2::<f64>::zeros((0, 0));
+        let empty_dm = DenseMatrix::from_ndarray2(&empty_nd);
+        assert_eq!(Array::is_empty(&empty_nd), Array::is_empty(&empty_dm));
+
+        let nonempty_nd: NdArray2<f64> = arr2(&[[1.0, 2.0], [3.0, 4.0]]);
+        let nonempty_dm = DenseMatrix::from_ndarray2(&nonempty_nd);
+        assert_eq!(Array::is_empty(&nonempty_nd), Array::is_empty(&nonempty_dm));
+    }
+
+    // ── iterator axis=0 (row-major) ───────────────────────────────────────────
+
+    #[test]
+    fn ndarray_iterator_axis0_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        let nd_vals: Vec<i32> = nd.iterator(0).copied().collect();
+        let dm_vals: Vec<i32> = dm.iterator(0).copied().collect();
+        assert_eq!(nd_vals, dm_vals, "axis=0 iterator mismatch");
+    }
+
+    // ── iterator axis=1 (column-major) ────────────────────────────────────────
+
+    #[test]
+    fn ndarray_iterator_axis1_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        let nd_vals: Vec<i32> = nd.iterator(1).copied().collect();
+        let dm_vals: Vec<i32> = dm.iterator(1).copied().collect();
+        assert_eq!(nd_vals, dm_vals, "axis=1 iterator mismatch");
+    }
+
+    // ── get_row ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_get_row_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        for r in 0..3 {
+            let nd_row = Array2::get_row(&nd, r);
+            let dm_row = Array2::get_row(&dm, r);
+            assert_eq!(nd_row.shape(), dm_row.shape());
+            for c in 0..3 {
+                assert_eq!(nd_row.get(c), dm_row.get(c), "row {r} col {c}");
+            }
+        }
+    }
+
+    // ── get_col ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_get_col_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2], [3, 4], [5, 6]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        for c in 0..2 {
+            let nd_col = Array2::get_col(&nd, c);
+            let dm_col = Array2::get_col(&dm, c);
+            assert_eq!(nd_col.shape(), dm_col.shape());
+            for r in 0..3 {
+                assert_eq!(nd_col.get(r), dm_col.get(r), "col {c} row {r}");
+            }
+        }
+    }
+
+    // ── slice ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_slice_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        let nd_slice = Array2::slice(&nd, 1..3, 0..2);
+        let dm_slice = Array2::slice(&dm, 1..3, 0..2);
+        assert_eq!(nd_slice.shape(), dm_slice.shape());
+        for r in 0..2 {
+            for c in 0..2 {
+                assert_eq!(nd_slice.get((r, c)), dm_slice.get((r, c)), "slice ({r},{c})");
+            }
+        }
+    }
+
+    // ── fill ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_fill_parity() {
+        let nd = <NdArray2<f64> as Array2<f64>>::fill(3, 4, 7.0);
+        let dm = <DenseMatrix<f64> as Array2<f64>>::fill(3, 4, 7.0);
+        assert_eq!(Array::shape(&nd), Array::shape(&dm));
+        assert_eq!(nd.iterator(0).copied().collect::<Vec<_>>(),
+                   dm.iterator(0).copied().collect::<Vec<_>>());
+    }
+
+    // ── transpose ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ndarray_transpose_parity() {
+        let nd: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6]]);
+        let dm = DenseMatrix::from_ndarray2(&nd);
+        let nd_t = Array2::transpose(&nd);
+        let dm_t = Array2::transpose(&dm);
+        assert_eq!(Array::shape(&nd_t), Array::shape(&dm_t));
+        let nd_vals: Vec<i32> = nd_t.iterator(0).copied().collect();
+        let dm_vals: Vec<i32> = dm_t.iterator(0).copied().collect();
+        assert_eq!(nd_vals, dm_vals, "transpose row-major values mismatch");
+    }
+
+    // ── from_ndarray2 round-trip ──────────────────────────────────────────────
+
+    #[test]
+    fn from_ndarray2_round_trip_values() {
+        let original: NdArray2<f64> = arr2(&[
+            [1.1, 2.2, 3.3],
+            [4.4, 5.5, 6.6],
+            [7.7, 8.8, 9.9],
+        ]);
+        let dm = DenseMatrix::from_ndarray2(&original);
+        for r in 0..3 {
+            for c in 0..3 {
+                assert_close_f64(
+                    *Array::get(&dm, (r, c)),
+                    *original.get((r, c)).unwrap(),
+                    1e-10,
+                    &format!("round-trip ({r},{c})"),
+                );
+            }
+        }
+    }
+
+    // ── Fortran-order (transposed layout) ────────────────────────────────────
+
+    #[test]
+    fn from_ndarray2_fortran_order_correct() {
+        let c_order: NdArray2<i32> = arr2(&[[1, 2, 3], [4, 5, 6]]);
+        let f_order = c_order.t().to_owned(); // shape (3,2), Fortran layout
+        let dm = DenseMatrix::from_ndarray2(&f_order);
+        // from_ndarray2 must always read logical order, so element (0,0) == 1
+        assert_eq!(*Array::get(&dm, (0, 0)), *f_order.get((0, 0)).unwrap());
+        assert_eq!(*Array::get(&dm, (2, 1)), *f_order.get((2, 1)).unwrap());
+    }
+}

--- a/src/tests_stage5_serde.rs
+++ b/src/tests_stage5_serde.rs
@@ -1,0 +1,209 @@
+//! Stage 5: serde round-trip tests for every serializable type.
+//!
+//! Gated on `#[cfg(feature = "serde")]` so they only run under
+//! `cargo test --features serde` (or `--all-features`).
+//!
+//! Tracking issue: #396 / #391.
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trips {
+    use serde_json;
+
+    // ── DenseMatrix ──────────────────────────────────────────────────────────
+
+    use crate::linalg::basic::matrix::DenseMatrix;
+    use crate::linalg::basic::arrays::Array;
+
+    #[test]
+    fn dense_matrix_serde_json_round_trip() {
+        let m = DenseMatrix::from_2d_array(&[
+            &[1.0_f64, 2.0, 3.0],
+            &[4.0, 5.0, 6.0],
+        ])
+        .unwrap();
+        let json = serde_json::to_string(&m).expect("serialize DenseMatrix");
+        let m2: DenseMatrix<f64> = serde_json::from_str(&json).expect("deserialize DenseMatrix");
+        assert_eq!(m.shape(), m2.shape());
+        for r in 0..2 {
+            for c in 0..3 {
+                assert!(
+                    (m.get((r, c)) - m2.get((r, c))).abs() < 1e-10,
+                    "mismatch at ({r},{c})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dense_matrix_i32_serde_json_round_trip() {
+        let m = DenseMatrix::from_2d_array(&[&[1_i32, 2, 3], &[4, 5, 6]]).unwrap();
+        let json = serde_json::to_string(&m).unwrap();
+        let m2: DenseMatrix<i32> = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, m2);
+    }
+
+    // ── KNNClassifier ────────────────────────────────────────────────────────
+
+    use crate::neighbors::knn_classifier::{KNNClassifier, KNNClassifierParameters};
+    use crate::metrics::distance::Distances;
+    use crate::algorithm::neighbour::KNNAlgorithmName;
+    use crate::neighbors::KNNWeightFunction;
+
+    #[test]
+    fn knn_classifier_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64, 2.0], &[2.0, 3.0], &[3.0, 4.0],
+            &[10.0, 11.0], &[11.0, 12.0], &[12.0, 13.0],
+        ])
+        .unwrap();
+        let y: Vec<u32> = vec![0, 0, 0, 1, 1, 1];
+        let params = KNNClassifierParameters::default()
+            .with_k(3)
+            .with_algorithm(KNNAlgorithmName::LinearSearch)
+            .with_weight(KNNWeightFunction::Uniform);
+        let model = KNNClassifier::fit(&x, &y, params).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize KNNClassifier");
+        let model2: KNNClassifier<f64, u32, DenseMatrix<f64>, _> =
+            serde_json::from_str(&json).expect("deserialize KNNClassifier");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        assert_eq!(pred1, pred2, "KNNClassifier round-trip prediction mismatch");
+    }
+
+    // ── KNNRegressor ─────────────────────────────────────────────────────────
+
+    use crate::neighbors::knn_regressor::{KNNRegressor, KNNRegressorParameters};
+
+    #[test]
+    fn knn_regressor_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64], &[2.0], &[3.0], &[4.0], &[5.0],
+        ])
+        .unwrap();
+        let y: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let params = KNNRegressorParameters::default().with_k(2);
+        let model = KNNRegressor::fit(&x, &y, params).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize KNNRegressor");
+        let model2: KNNRegressor<f64, f64, DenseMatrix<f64>, _> =
+            serde_json::from_str(&json).expect("deserialize KNNRegressor");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        for (a, b) in pred1.iter().zip(pred2.iter()) {
+            assert!((a - b).abs() < 1e-10, "KNNRegressor round-trip mismatch");
+        }
+    }
+
+    // ── DecisionTreeClassifier ───────────────────────────────────────────────
+
+    use crate::tree::decision_tree_classifier::{DecisionTreeClassifier, DecisionTreeClassifierParameters};
+
+    #[test]
+    fn decision_tree_classifier_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[0.0_f64, 0.0], &[0.0, 1.0], &[1.0, 0.0], &[1.0, 1.0],
+            &[0.0, 0.0], &[0.0, 1.0], &[1.0, 0.0], &[1.0, 1.0],
+        ])
+        .unwrap();
+        let y: Vec<u32> = vec![0, 0, 1, 1, 0, 0, 1, 1];
+        let params = DecisionTreeClassifierParameters::default().with_max_depth(3);
+        let model = DecisionTreeClassifier::fit(&x, &y, params).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize DecisionTreeClassifier");
+        let model2: DecisionTreeClassifier<f64, u32, DenseMatrix<f64>, Vec<u32>> =
+            serde_json::from_str(&json).expect("deserialize DecisionTreeClassifier");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        assert_eq!(pred1, pred2);
+    }
+
+    // ── DecisionTreeRegressor ────────────────────────────────────────────────
+
+    use crate::tree::decision_tree_regressor::{DecisionTreeRegressor, DecisionTreeRegressorParameters};
+
+    #[test]
+    fn decision_tree_regressor_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64], &[2.0], &[3.0], &[4.0], &[5.0], &[6.0],
+        ])
+        .unwrap();
+        let y: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let params = DecisionTreeRegressorParameters::default().with_max_depth(3);
+        let model = DecisionTreeRegressor::fit(&x, &y, params).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize DecisionTreeRegressor");
+        let model2: DecisionTreeRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>> =
+            serde_json::from_str(&json).expect("deserialize DecisionTreeRegressor");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        for (a, b) in pred1.iter().zip(pred2.iter()) {
+            assert!((a - b).abs() < 1e-6);
+        }
+    }
+
+    // ── LinearRegression ─────────────────────────────────────────────────────
+
+    use crate::linear::linear_regression::{LinearRegression, LinearRegressionParameters};
+    use crate::SupervisedEstimator;
+
+    #[test]
+    fn linear_regression_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64], &[2.0], &[3.0], &[4.0], &[5.0],
+        ])
+        .unwrap();
+        let y: Vec<f64> = vec![2.0, 4.0, 6.0, 8.0, 10.0];
+        let model = LinearRegression::fit(&x, &y, LinearRegressionParameters::default()).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize LinearRegression");
+        let model2: LinearRegression<f64, DenseMatrix<f64>, Vec<f64>> =
+            serde_json::from_str(&json).expect("deserialize LinearRegression");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        for (a, b) in pred1.iter().zip(pred2.iter()) {
+            assert!((a - b).abs() < 1e-6, "LinearRegression round-trip mismatch");
+        }
+    }
+
+    // ── GaussianNB ───────────────────────────────────────────────────────────
+
+    use crate::naive_bayes::gaussian::{GaussianNB, GaussianNBParameters};
+
+    #[test]
+    fn gaussian_nb_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64, 0.0], &[1.1, 0.1], &[0.9, -0.1],
+            &[-1.0, 0.0], &[-1.1, 0.1], &[-0.9, -0.1],
+        ])
+        .unwrap();
+        let y: Vec<u32> = vec![0, 0, 0, 1, 1, 1];
+        let model = GaussianNB::fit(&x, &y, GaussianNBParameters::default()).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize GaussianNB");
+        let model2: GaussianNB<f64, u32, DenseMatrix<f64>, Vec<u32>> =
+            serde_json::from_str(&json).expect("deserialize GaussianNB");
+        let pred1 = model.predict(&x).unwrap();
+        let pred2 = model2.predict(&x).unwrap();
+        assert_eq!(pred1, pred2, "GaussianNB round-trip prediction mismatch");
+    }
+
+    // ── PCA ──────────────────────────────────────────────────────────────────
+
+    use crate::decomposition::pca::{PCA, PCAParameters};
+    use crate::Transformer;
+
+    #[test]
+    fn pca_serde_json_round_trip() {
+        let x = DenseMatrix::from_2d_array(&[
+            &[1.0_f64, 2.0, 3.0],
+            &[4.0, 5.0, 6.0],
+            &[7.0, 8.0, 9.0],
+            &[2.0, 3.0, 4.0],
+            &[5.0, 6.0, 7.0],
+        ])
+        .unwrap();
+        let params = PCAParameters::default().with_n_components(2);
+        let model = PCA::fit(&x, params).unwrap();
+        let json = serde_json::to_string(&model).expect("serialize PCA");
+        let model2: PCA<f64, DenseMatrix<f64>> =
+            serde_json::from_str(&json).expect("deserialize PCA");
+        let t1 = model.transform(&x).unwrap();
+        let t2 = model2.transform(&x).unwrap();
+        assert_eq!(t1.shape(), t2.shape());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #396. Adds the Stage 5 test coverage for three cross-cutting, feature-gated areas that were missing from the test suite:

### Files added

| File | Coverage |
|------|----------|
| `src/tests_stage5_serde.rs` | `#[cfg(feature = "serde")]` round-trip JSON tests for `DenseMatrix`, `KNNClassifier`, `KNNRegressor`, `DecisionTreeClassifier`, `DecisionTreeRegressor`, `LinearRegression`, `GaussianNB`, `PCA` |
| `src/tests_stage5_datasets.rs` | `#[cfg(feature = "datasets")]` shape / cardinality / feature-name smoke-tests for all five bundled loaders (`boston`, `breast_cancer`, `diabetes`, `digits`, `iris`) plus edge-case generator tests (`make_blobs`, `make_circles`, `make_moons`) |
| `src/tests_stage5_ndarray.rs` | `#[cfg(feature = "ndarray-bindings")]` parity tests asserting that `ArrayBase<OwnedRepr<T>, Ix2>` and `DenseMatrix<T>` produce identical results for `shape`, `get`, `is_empty`, `iterator` (both axes), `get_row`, `get_col`, `slice`, `fill`, `transpose`, and Fortran-layout `from_ndarray2` |

### Design notes
- All tests are fully gated behind their respective feature flags — no compile-time overhead under `cargo test` without the feature.
- Generator edge-cases cover single-sample, zero-noise, and minimal-samples paths that were previously untested.
- Serde tests verify prediction equality after a serialise→deserialise round-trip, not just structural equality.
- All `make_*` and loader tests carry the `wasm_bindgen_test` attribute for wasm32 compatibility consistent with the rest of the dataset module.

### How to run
```bash
cargo test --features serde         # serde round-trips
cargo test --features datasets      # dataset loaders + generators
cargo test --features ndarray-bindings  # ndarray parity
cargo test --all-features           # all of the above
```