### PR TITLE
docs: target main branch for PRs, workflows, and install instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,6 +67,6 @@ $ rust-code-analysis-cli -p src/algorithm/neighbour/fastpair.rs --ls 22 --le 213
   
 * **read history**: search past open or closed issues for your problem before opening a new issue.
 
-* **PRs on develop**: any change should be PRed first in `development`
+* **PRs on main**: any change should be PRed first in `main`
 
 * **testing**:  everything should work and be tested as defined in the workflow. If any is failing for non-related reasons, annotate the test failure in the PR comment.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 Fixes #
 
 ### Checklist
-- [ ] My branch is up-to-date with development branch.
+- [ ] My branch is up-to-date with main branch.
 - [ ] Everything works and tested on latest stable Rust.
 - [ ] Coverage and Linting have been applied 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development]
+    branches: [main]
   pull_request:
-    branches: [development]
+    branches: [main]
 
 jobs:
   tests:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ main, development ]
+    branches: [ main ]
   pull_request:
-    branches: [ development ]
+    branches: [ main ]
 
 jobs:
   coverage:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint checks
 
 on:
   push:
-    branches: [ main, development ]
+    branches: [ main ]
   pull_request:
-    branches: [ development ]
+    branches: [ main ]
 
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Agent-focused guidance for working on the `smartcore` Rust machine-learning libr
 
 - **Language / edition**: Rust 2024 (MSRV 1.85 — verified by the `msrv` CI job).
 - **Repository**: https://github.com/smartcorelib/smartcore
-- **Default branch**: `development`. All changes should target `development` first.
+- **Default branch**: `main`. All changes should target `main` first.
 - **License**: Apache-2.0.
 - **Authors**: "smartcore Developers".
 
@@ -72,7 +72,7 @@ When touching feature-gated code, run at least `cargo build --all-features` and 
 
 - Open an issue describing the change before starting significant work.
 - Search open and closed issues/PRs for related discussion.
-- Open PRs against the `development` branch.
+- Open PRs against the `main` branch.
 - Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and erase sections that do not apply.
 - Update `CHANGELOG.md` for breaking changes, new environment variables, exposed ports, useful file locations, and container parameters.
 - Ensure CI checks pass:

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Add to Cargo.toml:
 smartcore = "^0.6"
 ```
 
-For the latest development branch:
+For the latest changes from the `main` branch:
 
 ```toml
 [dependencies]
-smartcore = { git = "https://github.com/smartcorelib/smartcore", branch = "development" }
+smartcore = { git = "https://github.com/smartcorelib/smartcore", branch = "main" }
 ```
 
 Optional features (examples):
@@ -147,7 +147,7 @@ Open the URLs above in a browser. Each page shows a searchable line chart (`data
 Contributions are welcome:
 
 - Open an issue describing the change and link it in the PR.
-- Keep PRs in sync with the development branch and ensure tests pass on stable Rust (MSRV 1.85, edition 2024).
+- Keep PRs in sync with the main branch and ensure tests pass on stable Rust (MSRV 1.85, edition 2024).
 - Provide or update tests; run clippy and apply formatting. Coverage and linting are part of the workflow.
 - Use the provided PR and issue templates to describe behavior changes, new features, and expectations.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,10 @@
 //! smartcore = "*"
 //! ```
 //!
-//! To start using smartcore development version with latest unstable additions:
+//! To start using smartcore latest additions from the `main` branch:
 //! ```ignore
 //! [dependencies]
-//! smartcore = { git = "https://github.com/smartcorelib/smartcore", branch = "development" }
+//! smartcore = { git = "https://github.com/smartcorelib/smartcore", branch = "main" }
 //! ```
 //!
 //! There are different features that can be added to the base library, for example to add sample datasets:


### PR DESCRIPTION
### Summary

All workflows now run on `main`, so documentation and CI triggers are updated to match.

### Changes

- AGENTS.md, README.md, CONTRIBUTING.md, PR template: PR target and default branch references changed from `development` to `main`
- README.md and src/lib.rs docs: git install snippet now uses `branch = "main"`
- .github/workflows/ci.yml, lint.yml, coverage.yml: push and pull_request triggers narrowed to `main` only

### Checklist

- [x] Docs-only change; no library code touched
- [x] Branch is up-to-date with main branch