### PR TITLE
fix: fuse StandardScaler::transform to single-allocation pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smartcore"
 description = "Machine Learning in Rust."
 homepage = "https://smartcorelib.github.io/"
-version = "0.6.12"
+version = "0.6.13"
 authors = ["smartcore Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/src/ensemble/base_forest_regressor.rs
+++ b/src/ensemble/base_forest_regressor.rs
@@ -89,6 +89,12 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
         if n_rows != y.shape() {
             return Err(Failed::fit("Number of rows in X should = len(y)"));
         }
+        if n_rows == 0 || num_attributes == 0 {
+            return Err(Failed::because(
+                FailedError::ParametersError,
+                "Training data must contain at least one sample and one feature.",
+            ));
+        }
 
         let mtry = parameters
             .m
@@ -223,6 +229,7 @@ impl<TX: Number + FloatNumber + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::linalg::basic::arrays::Array;
     use crate::linalg::basic::matrix::DenseMatrix;
 
     #[test]
@@ -243,5 +250,32 @@ mod tests {
         let regressor = BaseForestRegressor::fit(&x, &y, params).unwrap();
         assert_eq!(regressor.trees.unwrap().len(), 5);
         assert!(regressor.samples.is_some());
+    }
+
+    #[test]
+    fn test_fit_on_empty_data_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the empty-row case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let empty = full.take(&[] as &[usize], 0);
+        assert_eq!(empty.shape(), (0, 2));
+
+        let y: Vec<f64> = vec![];
+        let result = BaseForestRegressor::fit(
+            &empty,
+            &y,
+            BaseForestRegressorParameters {
+                max_depth: None,
+                min_samples_leaf: 1,
+                min_samples_split: 2,
+                n_trees: 5,
+                m: None,
+                keep_samples: false,
+                seed: 0,
+                bootstrap: true,
+                splitter: crate::tree::base_tree_regressor::Splitter::Best,
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
 }

--- a/src/ensemble/base_forest_regressor.rs
+++ b/src/ensemble/base_forest_regressor.rs
@@ -278,4 +278,31 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
+
+    #[test]
+    fn test_fit_on_zero_features_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the zero-feature case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let no_features = full.take(&[] as &[usize], 1);
+        assert_eq!(no_features.shape(), (2, 0));
+
+        let y: Vec<f64> = vec![1.0, 2.0];
+        let result = BaseForestRegressor::fit(
+            &no_features,
+            &y,
+            BaseForestRegressorParameters {
+                max_depth: None,
+                min_samples_leaf: 1,
+                min_samples_split: 2,
+                n_trees: 5,
+                m: None,
+                keep_samples: false,
+                seed: 0,
+                bootstrap: true,
+                splitter: crate::tree::base_tree_regressor::Splitter::Best,
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
+    }
 }

--- a/src/ensemble/random_forest_classifier.rs
+++ b/src/ensemble/random_forest_classifier.rs
@@ -461,6 +461,12 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
         if x_nrows != y_ncols {
             return Err(Failed::fit("Number of rows in X should = len(y)"));
         }
+        if x_nrows == 0 || num_attributes == 0 {
+            return Err(Failed::because(
+                FailedError::ParametersError,
+                "Training data must contain at least one sample and one feature.",
+            ));
+        }
 
         let mut yi: Vec<usize> = vec![0; y_ncols];
         let classes = y.unique();
@@ -619,6 +625,7 @@ impl<TX: FloatNumber + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::linalg::basic::arrays::Array;
     use crate::linalg::basic::matrix::DenseMatrix;
     use crate::metrics::*;
 
@@ -777,6 +784,32 @@ mod tests {
         );
 
         assert!(fail.is_err());
+    }
+
+    #[test]
+    fn test_fit_on_empty_data_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the empty-row case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64, 1.0], vec![0.0, 1.0]]).unwrap();
+        let empty = full.take(&[] as &[usize], 0);
+        assert_eq!(empty.shape(), (0, 2));
+
+        let y: Vec<u32> = vec![];
+        let result = RandomForestClassifier::fit(
+            &empty,
+            &y,
+            RandomForestClassifierParameters {
+                criterion: SplitCriterion::Gini,
+                max_depth: None,
+                min_samples_leaf: 1,
+                min_samples_split: 2,
+                n_trees: 10,
+                m: None,
+                keep_samples: false,
+                seed: 0,
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
 
     #[cfg_attr(

--- a/src/preprocessing/numerical.rs
+++ b/src/preprocessing/numerical.rs
@@ -138,76 +138,36 @@ impl<T: Number + RealNumber, M: Array2<T>> UnsupervisedEstimator<M, StandardScal
 /// standard deviation to one.
 impl<T: Number + RealNumber, M: Array2<T>> Transformer<M> for StandardScaler<T> {
     fn transform(&self, x: &M) -> Result<M, Failed> {
-        let (_, n_cols) = x.shape();
-        if n_cols != self.means.len() {
+        let (nrows, ncols) = x.shape();
+        if ncols != self.means.len() {
             return Err(Failed::because(
                 FailedError::TransformFailed,
                 &format!(
                     "Expected {} columns, but got {} columns instead.",
                     self.means.len(),
-                    n_cols,
+                    ncols,
                 ),
             ));
         }
 
-        Ok(build_matrix_from_columns(
-            self.means
-                .iter()
-                .zip(self.stds.iter())
-                .enumerate()
-                .map(|(column_index, (column_mean, column_std))| {
-                    x.take_column(column_index)
-                        .sub_scalar(T::from(self.adjust_column_mean(*column_mean)).unwrap())
-                        .div_scalar(T::from(self.adjust_column_std(*column_std)).unwrap())
-                })
-                .collect(),
-        )
-        .unwrap())
+        let mut output = M::fill(nrows, ncols, T::zero());
+        for j in 0..ncols {
+            let mean = T::from(self.adjust_column_mean(self.means[j])).unwrap();
+            let std = T::from(self.adjust_column_std(self.stds[j])).unwrap();
+            for i in 0..nrows {
+                let val = *x.get((i, j));
+                output.set((i, j), (val - mean) / std);
+            }
+        }
+        Ok(output)
     }
-}
-
-/// From a collection of matrices, that contain columns, construct
-/// a matrix by stacking the columns horizontally.
-fn build_matrix_from_columns<T, M>(columns: Vec<M>) -> Option<M>
-where
-    T: Number + RealNumber,
-    M: Array2<T>,
-{
-    columns.first().cloned().map(|output_matrix| {
-        columns
-            .iter()
-            .skip(1)
-            .fold(output_matrix, |current_matrix, new_colum| {
-                current_matrix.h_stack(new_colum)
-            })
-    })
 }
 
 #[cfg(test)]
 mod tests {
 
     mod helper_functionality {
-        use super::super::{build_matrix_from_columns, ensure_std_valid};
-        use crate::linalg::basic::matrix::DenseMatrix;
-
-        #[test]
-        fn combine_three_columns() {
-            assert_eq!(
-                build_matrix_from_columns(vec![
-                    DenseMatrix::from_2d_vec(&vec![vec![1.0], vec![1.0], vec![1.0],]).unwrap(),
-                    DenseMatrix::from_2d_vec(&vec![vec![2.0], vec![2.0], vec![2.0],]).unwrap(),
-                    DenseMatrix::from_2d_vec(&vec![vec![3.0], vec![3.0], vec![3.0],]).unwrap()
-                ]),
-                Some(
-                    DenseMatrix::from_2d_vec(&vec![
-                        vec![1.0, 2.0, 3.0],
-                        vec![1.0, 2.0, 3.0],
-                        vec![1.0, 2.0, 3.0]
-                    ])
-                    .unwrap()
-                )
-            )
-        }
+        use super::super::ensure_std_valid;
 
         #[test]
         fn negative_value_should_be_replace_with_minimal_positive_value() {
@@ -424,6 +384,128 @@ mod tests {
                     .transform(&DenseMatrix::from_2d_array(&[&[0.0, 9.0], &[4.0, 12.0]]).unwrap()),
                 Ok(DenseMatrix::from_2d_array(&[&[0.0, 3.0], &[2.0, 4.0]]).unwrap())
             )
+        }
+
+        /// Verify transform correctness across all parameter combinations.
+        #[test]
+        fn transform_all_parameter_combinations() {
+            let data = DenseMatrix::from_2d_vec(&vec![
+                vec![1.0, 10.0, 100.0],
+                vec![2.0, 20.0, 200.0],
+                vec![3.0, 30.0, 300.0],
+                vec![4.0, 40.0, 400.0],
+            ])
+            .unwrap();
+
+            // Default: with_mean=true, with_std=true
+            // std = population std: sqrt(mean of squared deviations)
+            // For [1,2,3,4]: mean=2.5, pop_std = sqrt(5/4) ≈ 1.1180339887
+            let scaler = StandardScaler::fit(&data, StandardScalerParameters::default()).unwrap();
+            let result = scaler.transform(&data).unwrap();
+            let expected = DenseMatrix::from_2d_vec(&vec![
+                vec![
+                    -1.3416407864998738,
+                    -1.3416407864998738,
+                    -1.3416407864998738,
+                ],
+                vec![
+                    -0.4472135954999579,
+                    -0.4472135954999579,
+                    -0.4472135954999579,
+                ],
+                vec![0.4472135954999579, 0.4472135954999579, 0.4472135954999579],
+                vec![1.3416407864998738, 1.3416407864998738, 1.3416407864998738],
+            ])
+            .unwrap();
+            assert!(
+                result.approximate_eq(&expected, 1e-10),
+                "Default transform failed:\n{result}\nexpected:\n{expected}"
+            );
+
+            // with_mean=true, with_std=false
+            let scaler = StandardScaler::fit(
+                &data,
+                StandardScalerParameters {
+                    with_mean: true,
+                    with_std: false,
+                },
+            )
+            .unwrap();
+            let result = scaler.transform(&data).unwrap();
+            let expected = DenseMatrix::from_2d_vec(&vec![
+                vec![-1.5, -15.0, -150.0],
+                vec![-0.5, -5.0, -50.0],
+                vec![0.5, 5.0, 50.0],
+                vec![1.5, 15.0, 150.0],
+            ])
+            .unwrap();
+            assert!(
+                result.approximate_eq(&expected, 1e-10),
+                "with_mean=true, with_std=false transform failed:\n{result}\nexpected:\n{expected}"
+            );
+
+            // with_mean=false, with_std=true: (x - 0) / std = x / std
+            let scaler = StandardScaler::fit(
+                &data,
+                StandardScalerParameters {
+                    with_mean: false,
+                    with_std: true,
+                },
+            )
+            .unwrap();
+            let result = scaler.transform(&data).unwrap();
+            let expected = DenseMatrix::from_2d_vec(&vec![
+                vec![0.8944271909999159, 0.8944271909999159, 0.8944271909999159],
+                vec![1.7888543819998317, 1.7888543819998317, 1.7888543819998317],
+                vec![2.6832815729997477, 2.6832815729997477, 2.6832815729997477],
+                vec![3.5777087639996634, 3.5777087639996634, 3.5777087639996634],
+            ])
+            .unwrap();
+            assert!(
+                result.approximate_eq(&expected, 1e-10),
+                "with_mean=false, with_std=true transform failed:\n{result}\nexpected:\n{expected}"
+            );
+
+            // with_mean=false, with_std=false (passthrough)
+            let scaler = StandardScaler::fit(
+                &data,
+                StandardScalerParameters {
+                    with_mean: false,
+                    with_std: false,
+                },
+            )
+            .unwrap();
+            let result = scaler.transform(&data).unwrap();
+            assert!(
+                result.approximate_eq(&data, 1e-10),
+                "with_mean=false, with_std=false should return data unchanged:\n{result}\nexpected:\n{data}"
+            );
+
+            // Zero-variance column mixed with normal columns
+            let mixed = DenseMatrix::from_2d_vec(&vec![
+                vec![1.0, 5.0],
+                vec![2.0, 5.0],
+                vec![3.0, 5.0],
+                vec![4.0, 5.0],
+            ])
+            .unwrap();
+            let scaler = StandardScaler::fit(&mixed, StandardScalerParameters::default()).unwrap();
+            let result = scaler.transform(&mixed).unwrap();
+            let expected = DenseMatrix::from_2d_vec(&vec![
+                vec![-1.3416407864998738, 0.0],
+                vec![-0.4472135954999579, 0.0],
+                vec![0.4472135954999579, 0.0],
+                vec![1.3416407864998738, 0.0],
+            ])
+            .unwrap();
+            assert!(
+                result.approximate_eq(&expected, 1e-10),
+                "Zero-variance mixed column transform failed:\n{result}\nexpected:\n{expected}"
+            );
+
+            // Column count mismatch returns error: scaler expects 2 cols, data has 1
+            let narrow = DenseMatrix::from_2d_vec(&vec![vec![1.0]]).unwrap();
+            assert!(scaler.transform(&narrow).is_err());
         }
 
         /// Same as `fit_for_random_values` test, but using a `StandardScaler` that has been

--- a/src/preprocessing/numerical.rs
+++ b/src/preprocessing/numerical.rs
@@ -151,10 +151,15 @@ impl<T: Number + RealNumber, M: Array2<T>> Transformer<M> for StandardScaler<T> 
         }
 
         let mut output = M::fill(nrows, ncols, T::zero());
-        for j in 0..ncols {
-            let mean = T::from(self.adjust_column_mean(self.means[j])).unwrap();
-            let std = T::from(self.adjust_column_std(self.stds[j])).unwrap();
-            for i in 0..nrows {
+        let col_params: Vec<(T, T)> = (0..ncols)
+            .map(|j| {
+                let mean = T::from(self.adjust_column_mean(self.means[j])).unwrap();
+                let std = T::from(self.adjust_column_std(self.stds[j])).unwrap();
+                (mean, std)
+            })
+            .collect();
+        for i in 0..nrows {
+            for (j, &(mean, std)) in col_params.iter().enumerate() {
                 let val = *x.get((i, j));
                 output.set((i, j), (val - mean) / std);
             }

--- a/src/tree/base_tree_regressor.rs
+++ b/src/tree/base_tree_regressor.rs
@@ -9,7 +9,7 @@ use rand::seq::SliceRandom;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::error::Failed;
+use crate::error::{Failed, FailedError};
 use crate::linalg::basic::arrays::{Array1, Array2, MutArrayView1};
 use crate::numbers::basenum::Number;
 use crate::rand_custom::get_rng_impl;
@@ -183,6 +183,12 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         let (x_nrows, num_attributes) = x.shape();
         if x_nrows != y.shape() {
             return Err(Failed::fit("Size of x should equal size of y"));
+        }
+        if x_nrows == 0 || num_attributes == 0 {
+            return Err(Failed::because(
+                FailedError::ParametersError,
+                "Training data must contain at least one sample and one feature.",
+            ));
         }
 
         let samples = vec![1; x_nrows];
@@ -539,5 +545,58 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>>
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::linalg::basic::arrays::Array;
+    use crate::linalg::basic::matrix::DenseMatrix;
+
+    #[test]
+    fn test_fit_on_empty_data_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the empty-row case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]).unwrap();
+        let empty = full.take(&[] as &[usize], 0);
+        assert_eq!(empty.shape(), (0, 2));
+
+        let y: Vec<f64> = vec![];
+        let result = BaseTreeRegressor::fit(
+            &empty,
+            &y,
+            BaseTreeRegressorParameters {
+                max_depth: None,
+                min_samples_leaf: 1,
+                min_samples_split: 2,
+                seed: None,
+                splitter: Splitter::Best,
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
+    }
+
+    #[test]
+    fn test_fit_on_zero_features_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the zero-feature case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]).unwrap();
+        let no_features = full.take(&[] as &[usize], 1);
+        assert_eq!(no_features.shape(), (2, 0));
+
+        let y = vec![1.0_f64, 2.0];
+        let result = BaseTreeRegressor::fit(
+            &no_features,
+            &y,
+            BaseTreeRegressorParameters {
+                max_depth: None,
+                min_samples_leaf: 1,
+                min_samples_split: 2,
+                seed: None,
+                splitter: Splitter::Best,
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
 }

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -76,7 +76,7 @@ use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 
 use crate::api::{Predictor, SupervisedEstimator};
-use crate::error::Failed;
+use crate::error::{Failed, FailedError};
 use crate::linalg::basic::arrays::MutArray;
 use crate::linalg::basic::arrays::{Array1, Array2, MutArrayView1};
 use crate::linalg::basic::matrix::DenseMatrix;
@@ -551,6 +551,12 @@ impl<TX: Number + PartialOrd, TY: Number + Ord, X: Array2<TX>, Y: Array1<TY>>
         let (x_nrows, num_attributes) = x.shape();
         if x_nrows != y.shape() {
             return Err(Failed::fit("Size of x should equal size of y"));
+        }
+        if x_nrows == 0 || num_attributes == 0 {
+            return Err(Failed::because(
+                FailedError::ParametersError,
+                "Training data must contain at least one sample and one feature.",
+            ));
         }
 
         let samples = vec![1; x_nrows];
@@ -1114,6 +1120,19 @@ mod tests {
         let fail = DecisionTreeClassifier::fit(&x_rand, &y, Default::default());
 
         assert!(fail.is_err());
+    }
+
+    #[test]
+    fn test_fit_on_empty_data_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the empty-row case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64, 1.0], vec![0.0, 1.0]]).unwrap();
+        let empty = full.take(&[] as &[usize], 0);
+        assert_eq!(empty.shape(), (0, 2));
+
+        let y: Vec<u32> = vec![];
+        let result = DecisionTreeClassifier::fit(&empty, &y, Default::default());
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
 
     #[cfg_attr(

--- a/src/tree/decision_tree_classifier.rs
+++ b/src/tree/decision_tree_classifier.rs
@@ -1135,6 +1135,19 @@ mod tests {
         assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
     }
 
+    #[test]
+    fn test_fit_on_zero_features_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the zero-feature case is under test
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64, 1.0], vec![0.0, 1.0]]).unwrap();
+        let no_features = full.take(&[] as &[usize], 1);
+        assert_eq!(no_features.shape(), (2, 0));
+
+        let y: Vec<u32> = vec![0, 1];
+        let result = DecisionTreeClassifier::fit(&no_features, &y, Default::default());
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().error(), FailedError::ParametersError);
+    }
+
     #[cfg_attr(
         all(target_arch = "wasm32", not(target_os = "wasi")),
         wasm_bindgen_test::wasm_bindgen_test

--- a/src/xgboost/xgb_regressor.rs
+++ b/src/xgboost/xgb_regressor.rs
@@ -534,11 +534,11 @@ impl<TX: Number + PartialOrd, TY: Number, X: Array2<TX>, Y: Array1<TY>> XGRegres
             ));
         }
 
-        let (n_samples, _) = data.shape();
-        if n_samples == 0 {
+        let (n_samples, n_features) = data.shape();
+        if n_samples == 0 || n_features == 0 {
             return Err(Failed::because(
                 FailedError::ParametersError,
-                "Training data must have at least one row.",
+                "Training data must contain at least one sample and one feature.",
             ));
         }
 
@@ -826,12 +826,25 @@ mod tests {
 
     #[test]
     fn test_fit_on_empty_data_returns_error() {
+        // 2 rows x 2 features — values are arbitrary; only the empty-row case is under test
         let full = DenseMatrix::from_2d_vec(&vec![vec![1.0, 1.0], vec![2.0, 1.0]]).unwrap();
         let empty = full.take(&[] as &[usize], 0);
         assert_eq!(empty.shape(), (0, 2));
 
         let y: Vec<f64> = vec![];
         let model = XGRegressor::fit(&empty, &y, XGRegressorParameters::default());
+        assert!(model.is_err());
+        assert_eq!(model.err().unwrap().error(), FailedError::ParametersError);
+    }
+
+    #[test]
+    fn test_fit_on_zero_features_returns_error() {
+        let full = DenseMatrix::from_2d_vec(&vec![vec![1.0, 1.0], vec![2.0, 1.0]]).unwrap();
+        let no_features = full.take(&[] as &[usize], 1);
+        assert_eq!(no_features.shape(), (2, 0));
+
+        let y = vec![1.0, 2.0];
+        let model = XGRegressor::fit(&no_features, &y, XGRegressorParameters::default());
         assert!(model.is_err());
         assert_eq!(model.err().unwrap().error(), FailedError::ParametersError);
     }


### PR DESCRIPTION
## Summary

Three focused fixes building on each other:

### 1. Fuse StandardScaler::transform (#449)
Replace per-column `take_column` / `sub_scalar` / `div_scalar` / `build_matrix_from_columns` pattern with a single `M::fill` + row-outer/col-inner element-wise `(x[i][j] - mean[j]) / std[j]` loop. Column parameters pre-computed into a `Vec<(T, T)>` outside the hot loop. Eliminates O(d) medium Vec allocations and several full-matrix temporaries that caused ~9500x wall-time regression and RSS inflation on large matrices (4000x4000: 85.9s -> 0.009s). Remove dead `build_matrix_from_columns` helper. Bump to 0.6.13.

### 2. Harden XGRegressor empty-data guard (#448 review)
Extend the `n_samples == 0` guard to also reject `n_features == 0`. Improve error message to "Training data must contain at least one sample and one feature." Add `test_fit_on_zero_features_returns_error`.

### 3. Guard all tree/ensemble fit methods against empty data
Add `n_samples == 0 || n_features == 0` guards to `DecisionTreeClassifier::fit`, `BaseTreeRegressor::fit`, `RandomForestClassifier::fit`, and `BaseForestRegressor::fit`. Previously these could panic (divide-by-zero, empty-range) or produce undefined models. All return `FailedError::ParametersError`.

Audit: `ExtraTreesRegressor::fit` and `RandomForestRegressor::fit` both delegate to `BaseForestRegressor::fit` which already has the guard — no changes needed.

## Files changed
- `src/preprocessing/numerical.rs` — fused row-major transform, removed dead code, comprehensive test
- `src/xgboost/xgb_regressor.rs` — extended guard, improved message, new test
- `src/tree/decision_tree_classifier.rs` — new guard + 2 tests (empty-rows + zero-features)
- `src/tree/base_tree_regressor.rs` — new guard + test module (2 tests)
- `src/ensemble/random_forest_classifier.rs` — new guard + test
- `src/ensemble/base_forest_regressor.rs` — new guard + 2 tests (empty-rows + zero-features)
- `Cargo.toml` — version bump to 0.6.13

## Verification
- `cargo test`: 441 unit + 26 integration + 70 doctests all pass
- `cargo fmt --check`: clean
- `cargo clippy --all-features -- -Drust-2018-idioms -Drust-2024-compatibility -Dwarnings`: clean
